### PR TITLE
Add blueprint to auto generate config/deploy.js

### DIFF
--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/deploy-config/files/config/deploy.js
+++ b/blueprints/deploy-config/files/config/deploy.js
@@ -1,0 +1,43 @@
+module.exports = {
+  //development: {
+    //store: {
+      //type: 'redis', // the default store is 'redis'
+      //host: 'localhost',
+      //port: 6379
+    //},
+    //assets: {
+      //type: 's3', // default asset-adapter is 's3'
+      //gzip: false, // if undefined or set to true, files are gziped
+      //gzipExtensions: ['js', 'css', 'svg'], // if undefined, js, css & svg files are gziped
+      //accessKeyId: '<your-access-key-goes-here>',
+      //secretAccessKey: process.env['AWS_ACCESS_KEY'],
+      //bucket: '<your-bucket-name>'
+    //}
+  //},
+
+  //staging: {
+    //buildEnv: 'staging', // Override the environment passed to the ember asset build. Defaults to 'production'
+    //store: {
+      //host: 'staging-redis.example.com',
+      //port: 6379
+    //},
+    //assets: {
+      //accessKeyId: '<your-access-key-goes-here>',
+      //secretAccessKey: process.env['AWS_ACCESS_KEY'],
+      //bucket: '<your-bucket-name>'
+    //}
+  //},
+
+  //production: {
+    //store: {
+      //host: 'production-redis.example.com',
+      //port: 6379,
+      //password: '<your-redis-secret>'
+    //},
+    //assets: {
+      //accessKeyId: '<your-access-key-goes-here>',
+      //secretAccessKey: process.env['AWS_ACCESS_KEY'],
+      //bucket: '<your-bucket-name>'
+    //}
+  //}
+}

--- a/blueprints/deploy-config/index.js
+++ b/blueprints/deploy-config/index.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Generate config for ember-cli deployments',
+  normalizeEntityName: function() {
+    // this prevents an error when the entityName is
+    // not specified (since that doesn't actually matter
+    // to us
+  }
+};

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var path     = require('path');
 var commands = require('./lib/commands');
 
 function Deploy() {
@@ -8,6 +9,10 @@ function Deploy() {
 Deploy.prototype.includedCommands = function() {
   return commands;
 }
+
+Deploy.prototype.blueprintsPath = function() {
+  return path.join(__dirname, 'blueprints');
+},
 
 module.exports = Deploy;
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "ember-cli-deploy"
   ],
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "defaultBlueprint": "deploy-config"
   },
   "dependencies": {
     "broccoli": "^0.13.2",


### PR DESCRIPTION
* Adds `deploy-config` blueprint to `ember generate`
* Populates config/deploy.js with example config

Closes #52 