### PR TITLE
update ember-deploy references to be ember-cli-deploy

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-deploy",
+  "name": "ember-cli-deploy",
   "dependencies": {
     "handlebars": "~1.3.0",
     "jquery": "^1.11.1",

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var path     = require('path');
 var commands = require('./lib/commands');
 
 function Deploy() {
-  this.name = "ember-deploy"
+  this.name = "ember-cli-deploy"
   return this;
 }
 

--- a/node-tests/unit/utilities/adapter-registry-test.js
+++ b/node-tests/unit/utilities/adapter-registry-test.js
@@ -1,6 +1,6 @@
+/* jshint expr:true */
 var Adapter         = require('../../../utilities/adapter');
 var AdapterRegistry = require('../../../utilities/adapter-registry');
-var CoreObject      = require('core-object');
 var UnknownAdapter  = require('../../../utilities/assets/unknown');
 var expect          = require('chai').expect;
 
@@ -37,7 +37,7 @@ describe('AdapterRegistry', function() {
       var adapterRegistry = new AdapterRegistry();
 
       expect(adapterRegistry.lookup('index', 'trolol')).to.eq(UnknownAdapter);
-    })
+    });
   });
 
   describe('adapters can be added via addons', function() {

--- a/node-tests/unit/utilities/tagging/sha-test.js
+++ b/node-tests/unit/utilities/tagging/sha-test.js
@@ -32,7 +32,7 @@ describe('ShaTaggingAdapter', function() {
 
   describe('#createTag', function() {
     it('returns a tag based on current git-sha and manifestName', function() {
-      var manifestName   = 'ember-deploy';
+      var manifestName   = 'ember-cli-deploy';
       var expectedTag    = manifestName+':'+GIT_SHA_SHORTENED;
       var revisionTagger = new ShaTaggingAdapter({
         manifest: manifestName

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "./node_modules/mocha/bin/mocha  node-tests/**/*-test.js",
     "autotest": "./node_modules/mocha/bin/mocha --watch --reporter spec node-tests/**/*-test.js"
   },
-  "repository": "https://github.com/ember-cli/ember-deploy",
+  "repository": "https://github.com/ember-cli/ember-cli-deploy",
   "engines": {
     "node": ">= 0.10.0"
   },

--- a/utilities/adapter-registry.js
+++ b/utilities/adapter-registry.js
@@ -5,7 +5,7 @@ var merge          = require('lodash-node/modern/objects/merge');
 
 module.exports = CoreObject.extend({
   init: function() {
-    if (!this.project) { return };
+    if (!this.project) { return; }
 
     this.project.addons.forEach(this._mergeDeployAdapters.bind(this));
   },


### PR DESCRIPTION
Alright, I think I covered getting all of these renamed properly. I left the readme and the changelog be as I expect these to get their own overhaul.