### PR TITLE
Fix regression to the type of object that was being passed to assets adapters as “config”.

### DIFF
--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -1,4 +1,5 @@
 var ConfigurationReader = require('../utilities/configuration-reader');
+var AssetsUploader = require('../utilities/assets-uploader');
 
 module.exports = {
   name: 'deploy',
@@ -35,7 +36,8 @@ module.exports = {
     var assetsTask = new AssetsTask({
       ui: this.ui,
       analytics: this.analytics,
-      project: this.project
+      project: this.project,
+      AssetsUploader: AssetsUploader
     });
     var deployIndexTask = new DeployIndexTask({
       ui: this.ui,

--- a/lib/commands/unsupported/assets.js
+++ b/lib/commands/unsupported/assets.js
@@ -1,4 +1,5 @@
 var UnsupportedCommand = require('./unsupported-command');
+var AssetsUploader = require('../../utilities/assets-uploader');
 
 module.exports = UnsupportedCommand({
   name: 'deploy:assets',
@@ -15,7 +16,8 @@ module.exports = UnsupportedCommand({
     var assetsTask = new AssetsTask({
       ui: this.ui,
       analytics: this.analytics,
-      project: this.project
+      project: this.project,
+      AssetsUploader: AssetsUploader
     });
 
     return assetsTask.run(commandOptions);

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -18,10 +18,53 @@ function getPath(config, propertyPath) {
   return node;
 }
 
+function setPath(config, propertyPath, value) {
+  var parts = propertyPath.split('.');
+  var lastPropertyPath = parts.pop()
+  function read(node, part){
+    if (node) {
+      return node[part];
+    } else {
+      return undefined;
+    }
+  }
+  var node = config;
+  var part = parts.shift()
+  while (part !== undefined && part !== null) {
+    node = read(node, part);
+    part = parts.shift();
+  }
+  node[lastPropertyPath] = value;
+}
+
 
 module.exports = CoreObject.extend({
   init: function() {
     this._config = this.rawConfig;
+    this._defaultPropertyPaths = {
+      'assets.gzip': true,
+      'assets.gzipExtensions': ['js', 'css', 'svg'],
+      'assets.type': 's3',
+      'buildEnv': 'production',
+      'manifestPrefix': this.project.name(),
+      'store.manifestSize': 10,
+      'store.type': 'redis',
+      'tagging': 'sha'
+    };
+  },
+
+  // This is a temporary method to preserve an API where we are giving an
+  // adapter a reference to the whole, raw config as a POJO. Remove it
+  // once we move away from that
+  _materialize: function(){
+    var materialized = JSON.parse(JSON.stringify(this._config));
+    var defaultPropertyPaths = this._defaultPropertyPaths;
+    Object.keys(defaultPropertyPaths).forEach(function(propertyPath){
+      if (!getPath(this._config, propertyPath)) {
+        setPath(materialized, propertyPath, defaultPropertyPaths[propertyPath]);
+      }
+    });
+    return materialized;
   },
   get: function(propertyPath) {
     var configValue = getPath(this._config, propertyPath);
@@ -32,25 +75,6 @@ module.exports = CoreObject.extend({
     }
   },
   defaultFor: function(propertyPath) {
-    switch(propertyPath) {
-      case 'buildEnv':
-        return 'production';
-      case 'manifestPrefix':
-        return this.project.name();
-      case 'assets.gzip':
-        return true;
-      case 'assets.type':
-        return 's3';
-      case 'assets.gzipExtensions':
-        return ['js', 'css', 'svg'];
-      case 'store.type':
-        return 'redis';
-      case 'store.manifestSize':
-        return 10;
-      case 'tagging':
-        return 'sha';
-      default:
-        return undefined;
-    }
+    return this._defaultPropertyPaths[propertyPath];
   }
 });

--- a/lib/tasks/assets.js
+++ b/lib/tasks/assets.js
@@ -10,8 +10,6 @@ var ncp   = Promise.denodeify(require('ncp'));
 var white = chalk.white;
 var green = chalk.green;
 
-var AssetsUploader = require('../utilities/assets-uploader');
-
 var EXPIRE_IN_2030 = new Date('2030');
 var TWO_YEAR_CACHE_PERIOD_IN_SEC = 60 * 60 * 24 * 365 * 2;
 
@@ -22,11 +20,12 @@ module.exports = Task.extend({
     var config = new ConfigurationReader({
       environment: options.environment,
       configFile: options.deployConfigFile,
+      project: this.project,
       ui: this.ui
     }).config;
 
     var fileTreeOrPath;
-    if(config.get('assets.gzip') === false) {
+    if (config.get('assets.gzip') === false) {
       fileTreeOrPath = 'dist';
     } else {
       var gzipFiles = require('broccoli-gzip');
@@ -51,12 +50,14 @@ module.exports = Task.extend({
     var config = new ConfigurationReader({
       environment: environment,
       configFile: configFile,
+      project: this.project,
       ui: this.ui
     }).config;
 
+    var AssetsUploader = this.AssetsUploader;
     var assetsUploader = new AssetsUploader({
       ui: this.ui,
-      config: config,
+      config: config._materialize(),
       type: config.get('assets.type'),
       project: this.project
     });

--- a/lib/utilities/configuration-reader.js
+++ b/lib/utilities/configuration-reader.js
@@ -11,6 +11,7 @@ function ConfigurationReader(options) {
   this._deployConfig = this._options.configFile || defaultConfigPath;
 
   var ui = options.ui;
+  var project = options.project;
 
   deprecate(
     "Using a .json file for deployment configuration is deprecated. Please use a .js file instead",
@@ -24,8 +25,9 @@ function ConfigurationReader(options) {
     ui.writeError(e);
     throw new Error('Cannot load configuration file \'' + pathToConfig + '\'. Note that the default location of the ember-cli-deploy config file is now \''+ defaultConfigPath + '\'');
   }
+
   this.config = new Config({
-    project: this.project,
+    project: project,
     rawConfig: this._config[this._environment]
   });
 }

--- a/node-tests/unit/tasks/assets-test.js
+++ b/node-tests/unit/tasks/assets-test.js
@@ -1,0 +1,36 @@
+var CoreObject = require('core-object');
+var AssetsTask = require('../../../lib/tasks/assets');
+var MockUI     = require('ember-cli/tests/helpers/mock-ui');
+var expect     = require('chai').expect;
+var path       = require('path');
+
+describe('AssetsTask', function() {
+  var ui, project, MockAssetsUploader, mockAssetsUploaderConfig;
+
+  beforeEach(function() {
+    mockAssetsUploaderConfig = null;
+    ui = new MockUI();
+    project = { name: function(){ return 'foo'; }}
+    MockAssetsUploader = CoreObject.extend({
+      init: function() {
+        mockAssetsUploaderConfig = this.config;
+      },
+      upload: function(){}
+    })
+  });
+  describe('#uploadAssets', function(){
+    it('receives a POJO config object (which is a bad idea and we should change this API)', function() {
+      var root = process.cwd();
+      var task = new AssetsTask({
+        ui: ui,
+        AssetsUploader: MockAssetsUploader,
+        project: project
+      });
+      var configFile = require(path.join(root, './config/deploy.js'));
+      task.uploadAssets('development', 'config/deploy.js');
+      expect(mockAssetsUploaderConfig.assets).to.be.exist;
+      expect(mockAssetsUploaderConfig.assets.bucket).to.equal('<your-bucket-name>');
+      expect(mockAssetsUploaderConfig.assets.type).to.equal('s3');
+    });
+  });
+});

--- a/node-tests/unit/utilities/configuration-reader-test.js
+++ b/node-tests/unit/utilities/configuration-reader-test.js
@@ -6,17 +6,19 @@ var EOL    = require('os').EOL;
 var chalk  = require('chalk');
 
 describe('ConfigurationReader', function() {
-  var ui;
+  var ui, project;
 
   beforeEach(function() {
     ui = new MockUI();
+    project = { name: function(){ return 'foo'; }}
   });
 
   describe('environment settings', function() {
     it('knows about its passed _environment', function() {
       var config = new ConfigurationReader({
         environment: 'staging',
-        ui: ui
+        ui: ui,
+        project: project
       });
 
       expect(config._environment).to.equal('staging');
@@ -24,7 +26,8 @@ describe('ConfigurationReader', function() {
 
     it('`development` is default when no environment is passed', function() {
       var config = new ConfigurationReader({
-        ui: ui
+        ui: ui,
+        project: project
       });
 
       expect(config._environment).to.equal('development');
@@ -40,7 +43,8 @@ describe('ConfigurationReader', function() {
 
       var config = new ConfigurationReader({
         configFile: configPath,
-        ui: ui
+        ui: ui,
+        project: project
       });
 
       expect(ui.output).to.include('DEPRECATION: Using a .json file for deployment configuration is deprecated. Please use a .js file instead');
@@ -55,7 +59,8 @@ describe('ConfigurationReader', function() {
 
       var config = new ConfigurationReader({
         configFile: configPath,
-        ui: ui
+        ui: ui,
+        project: project
       });
 
       expect(config._config).to.equal(expectedConfig);
@@ -66,7 +71,8 @@ describe('ConfigurationReader', function() {
       var expectedConfig = require(path.join(root, './config/deploy.js'));
 
       var config = new ConfigurationReader({
-        ui: ui
+        ui: ui,
+        project: project
       });
 
       expect(config._config).to.equal(expectedConfig)
@@ -79,7 +85,8 @@ describe('ConfigurationReader', function() {
       expect(function() {
         var config = new ConfigurationReader({
           configFile: configPath,
-          ui: ui
+          ui: ui,
+          project: project
         });
       }).to.throw('Cannot load configuration file \'' + path.join(root, configPath) + '\'. Note that the default location of the ember-cli-deploy config file is now \'config/deploy.js\'');
     });
@@ -96,7 +103,8 @@ describe('ConfigurationReader', function() {
 
         var config = new ConfigurationReader({
           environment: ENV,
-          ui: ui
+          ui: ui,
+          project: project
         }).config;
 
         expect(config.get('store')).to.deep.equal(expected);
@@ -115,7 +123,8 @@ describe('ConfigurationReader', function() {
 
         var config = new ConfigurationReader({
           environment: ENV,
-          ui: ui
+          ui: ui,
+          project: project
         }).config;
 
         expect(config.get('assets')).to.deep.equal(expected);


### PR DESCRIPTION
Fix regression to the type of object that was being passed to assets adapters as “config”. Closes #62

* Slight refactoring to AssetsTask to make it’s interaction with AssetsUploader more testable
* this change means we are not being as lazy with default values as before. That’s ok.
* ConfigurationReader now needs to be constructed with a project reference