### PR TITLE
ensure project is passed into all configuration readers

### DIFF
--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -19,6 +19,7 @@ module.exports = {
     var config = new ConfigurationReader({
       environment: commandOptions.environment,
       configFile: commandOptions.deployConfigFile,
+      project: this.project,
       ui: this.ui
     }).config;
     var buildTask = new BuildTask({

--- a/lib/tasks/activate.js
+++ b/lib/tasks/activate.js
@@ -15,6 +15,7 @@ module.exports = Task.extend({
     var config = new ConfigurationReader({
       environment: options.environment,
       configFile: options.deployConfigFile,
+      project: this.project,
       ui: ui
     }).config;
     var adapterType = config.get('store.type');

--- a/lib/tasks/deploy-index.js
+++ b/lib/tasks/deploy-index.js
@@ -13,6 +13,7 @@ module.exports = Task.extend({
     var config = new ConfigurationReader({
       environment: options.environment,
       configFile: options.deployConfigFile,
+      project: this.project,
       ui: ui
     }).config;
 

--- a/lib/tasks/list.js
+++ b/lib/tasks/list.js
@@ -9,6 +9,7 @@ module.exports = Task.extend({
     var config = new ConfigurationReader({
       environment: options.environment,
       configFile: options.deployConfigFile,
+      project: this.project,
       ui: ui
     }).config;
     var adapterType = config.get('store.type');


### PR DESCRIPTION
Noticed this as a regression. Will work to add some tests around the tasks to catch this in the future but this addresses a the regression for now.