### PR TITLE
npm post install message for users of v0.0.6

### DIFF
--- a/MIGRATION_STEPS.md
+++ b/MIGRATION_STEPS.md
@@ -1,0 +1,116 @@
+##Overview
+
+`achambers/ember-cli-deploy`, `LevelBossMike/ember-deploy` and `tedconf/ember-cli-front-end-builds` are coming together to create the offical Ember CLI deployment tool, `ember-cli/ember-cli-deploy`.
+
+Users upgrading from the `ember-cli-deploy` npm package `<= v0.0.6` to `>= v0.4.0` will need to follow the migration steps below as the core codebase of the package will be changing completely.
+
+While we are trying our best to maintain backwards compatability for users of `<= v0.0.6`, this will only be temporary and users are strongly urged to migrate ASAP.
+
+## Migrate config
+
+Migrate your `<= v0.0.6` config from this:
+
+```javascript
+// config/deploy/staging.js
+
+module.exports = {
+  assets: {
+    accessKeyId: process.env.AWS_ACCESS_KEY,
+    secretAccessKey: process.env.AWS_SECRET,
+    bucket: 'staging-bucket',
+    region: 'eu-west-1'
+  },
+
+  index: {
+    host: 'staging-redis.example.com',
+    port: '1234'
+  }
+};
+```
+
+```javascript
+// config/deploy/production.js
+
+module.exports = {
+  assets: {
+    accessKeyId: process.env.AWS_ACCESS_KEY,
+    secretAccessKey: process.env.AWS_SECRET,
+    bucket: 'prod-bucket',
+    region: 'eu-west-1'
+  },
+
+  index: {
+    host: 'production-redis.example.com',
+    port: '9876',
+    password: process.env.REDIS_PASSWORD
+  }
+};
+```
+
+to this:
+
+```javascript
+// config/deploy.js
+
+module.exports = {
+  staging: {
+    buildEnv: 'staging',
+    store: {
+      host: 'staging-redis.example.com',
+      port: 1234
+    },
+    assets: {
+      accessKeyId: process.env.AWS_ACCESS_KEY,
+      secretAccessKey: process.env.AWS_SECRET,
+      bucket: 'staging-bucket'
+      region: 'eu-west-1'
+    }
+  },
+
+   production: {
+    store: {
+      host: 'production-redis.example.com',
+      port: 9876,
+      password: process.env.REDIS_PASSWORD
+    },
+    assets: {
+      accessKeyId: process.env.AWS_ACCESS_KEY,
+      secretAccessKey: process.env.AWS_SECRET,
+      bucket: 'prod-bucket'
+      region: 'eu-west-1'
+    }
+  }
+};
+```
+
+## Migrate adapters
+
+Uninstall the now unsupported adapters:
+
+```shell
+$ npm uninstall ember-cli-deploy-redis-index-adapter --save-dev
+```
+
+And install the corresponding supported plugins:
+
+```shell
+$ npm install ember-deploy-redis --save-dev
+
+$ npm install ember-deploy-s3 --save-dev
+```
+
+## Serving of index.html
+
+Due to the way `v0.4.0` now stores the list of previous revisions, [achambers/fuzzy-wookie](https://github.com/achambers/fuzzy-wookie) is no longer compatible with ember-cli-deploy.
+
+If you were using [achambers/fuzzy-wookie](https://github.com/achambers/fuzzy-wookie), please migrate to use [philipheinser/ember-lightning](https://github.com/philipheinser/ember-lightning) instead.
+
+If you wrote your own server to serve the index.html, you will need to modify it in order for it to work with `v0.4.0`.  The breaking change is that instead of storing just `sha` in the list of previous revisions,ember-cli-deploy now stores `app-name:sha`.  Please make any changes necessary to your server to support this change.
+
+## Unsupported commands
+
+A number of commands became deprecated in `v0.4.0` and will become unsupported in future versions very soon.
+
+- instead of `ember deploy:index` and `ember deploy:assets`, please use `ember deploy`
+- instead of `ember activate`, please use `ember deploy:activate`
+- instead of `ember deploy:versions`, please use `ember deploy:list`

--- a/index.js
+++ b/index.js
@@ -1,5 +1,26 @@
-var path     = require('path');
-var commands = require('./lib/commands');
+var path                = require('path');
+var commands            = require('./lib/commands');
+var red                 = require('chalk').red;
+var grey                = require('chalk').grey;
+var hasDeprecatedConfig = require('./lib/utilities/detect-deprecated-config');
+
+if (hasDeprecatedConfig()) {
+    console.log(red('\n===========================================================================\n'));
+
+    console.log(red('NOTICE TO USERS OF ember-cli-deploy VERSION <= 0.0.6\n\n'));
+
+    console.log(grey('ember-cli/ember-cli-deploy') + red(' will now be using this npm module to host the\n'));
+    console.log(red('offial Ember CLI deployment tool.\n\n'));
+
+    console.log(red('Due to the changes being made, you should migrate your project to use the\n'));
+    console.log(red('new module now.\n\n'));
+
+    console.log(red('For more information on how to migrate from ') + grey('achambers/ember-cli-deploy') + red(' to ') + grey('ember-cli/ember-cli-deploy') + red(', please go to:\n\n'));
+
+    console.log(red('https://github.com/ember-cli/ember-cli-deploy/MIGRATION_STEPS.md'));
+
+    console.log(red('\n===========================================================================\n'));
+}
 
 function Deploy() {
   this.name = "ember-cli-deploy"
@@ -8,11 +29,10 @@ function Deploy() {
 
 Deploy.prototype.includedCommands = function() {
   return commands;
-}
+};
 
 Deploy.prototype.blueprintsPath = function() {
   return path.join(__dirname, 'blueprints');
-},
+};
 
 module.exports = Deploy;
-

--- a/lib/utilities/detect-deprecated-config.js
+++ b/lib/utilities/detect-deprecated-config.js
@@ -1,0 +1,8 @@
+var path = require('path');
+var glob = require('glob');
+
+module.exports = function() {
+  var deprecatedConfigPath = path.join(__dirname, '../../../..', 'config', 'deploy', '*.js');
+  var files = glob.sync(deprecatedConfigPath);
+  return files.length > 0;
+};


### PR DESCRIPTION
This PR:

- [x] adds a `MIGRATION_STEPS.md` file containing migration instructions for users of `v0.0.6`.
- [x] adds an npm `postinstall` script that warns users upgrading from `v0.0.6` and points them to the migration instructions
- [x] adds a utility function to detect if the user has defined config in the old location used by `v0.0.6`

Closes #69 and #70 