### PR TITLE
[BUGFIX] execSync compat issue #92

### DIFF
--- a/lib/utilities/tagging/sha.js
+++ b/lib/utilities/tagging/sha.js
@@ -1,19 +1,17 @@
 var CoreObject = require('core-object');
 
 module.exports = CoreObject.extend({
-  createTag: function() {
-    var commandResult;
-    if (require('child_process').execSync) {
-      commandResult = require('child_process').execSync("git rev-parse HEAD");
-    } else {
-      commandResult = require('execSync').exec("git rev-parse HEAD").stdout;
-    }
-    this._generateKey(commandResult);
+  init: function() {
+    this.syncExec = this.syncExec || require('sync-exec');
+  },
 
-    return this.revisionKey;
+  createTag: function() {
+    var commandResult = this.syncExec("git rev-parse HEAD").stdout;
+    return this._generateKey(commandResult);
   },
 
   _generateKey: function(sha) {
-    this.revisionKey = this.manifest+':'+sha.slice(0,7);
+    this.revisionKey = this.manifest + ':' + sha.slice(0,7);
+    return this.revisionKey;
   }
 });

--- a/node-tests/unit/utilities/tagging/sha-test.js
+++ b/node-tests/unit/utilities/tagging/sha-test.js
@@ -1,5 +1,4 @@
 var expect            = require('chai').expect;
-var sinon             = require('sinon');
 var ShaTaggingAdapter = require('../../../../lib/utilities/tagging/sha');
 
 var getShortShaVersion = function(sha) {
@@ -10,32 +9,17 @@ var GIT_SHA           = '04b724a6c656a21795067f9c344d22532cf593ae';
 var GIT_SHA_SHORTENED = getShortShaVersion(GIT_SHA);
 
 describe('ShaTaggingAdapter', function() {
-  var sandbox;
-
-  beforeEach(function() {
-    sandbox = sinon.sandbox.create();
-    if (require('child_process').execSync) {
-      sandbox
-        .stub(require('child_process'), 'execSync')
-        .returns(GIT_SHA);
-    } else {
-      // Node 0.10
-      sandbox
-        .stub(require('execSync'), 'exec')
-        .returns({stdout: GIT_SHA});
-    }
-  });
-
-  afterEach(function() {
-    sandbox.restore();
-  });
+  var mockSyncExec = function(){
+    return {stdout: GIT_SHA};
+  }
 
   describe('#createTag', function() {
     it('returns a tag based on current git-sha and manifestName', function() {
       var manifestName   = 'ember-cli-deploy';
-      var expectedTag    = manifestName+':'+GIT_SHA_SHORTENED;
+      var expectedTag    = manifestName + ':' + GIT_SHA_SHORTENED;
       var revisionTagger = new ShaTaggingAdapter({
-        manifest: manifestName
+        manifest: manifestName,
+        syncExec: mockSyncExec
       });
 
       expect(revisionTagger.createTag()).to.eq(expectedTag);

--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
     "broccoli-gzip": "^0.2.0",
     "chalk": "^0.5.1",
     "core-object": "0.0.2",
-    "execSync": "^1.0.2",
     "glob": "^4.0.5",
     "lodash-node": "^2.4.1",
     "mkdirp": "^0.5.0",
     "ncp": "^1.0.1",
-    "rimraf": "^2.2.8"
+    "rimraf": "^2.2.8",
+    "sync-exec": "^0.5.0"
   }
 }


### PR DESCRIPTION
branch is intended to resolve issues around `child_process` `execSync` compatibility among the nodejs versions and platforms it's installed on. [sync-exec](https://www.npmjs.com/package/sync-exec) is a good candidate. Another possible sol'n is latest version of [execSync](https://github.com/mgutz/execSync) as noted by @duizendnegen in https://github.com/ember-cli/ember-cli-deploy/issues/92

This PR uses [sync-exec](https://www.npmjs.com/package/sync-exec) and was confirmed to resolve https://github.com/ember-cli/ember-cli-deploy/issues/92 and is a potential fix for https://github.com/ember-cli/ember-cli-deploy/issues/90 