### PR TITLE
Update config around production-like environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,12 +150,26 @@ var isProductionLikeBuild = ['production', 'staging'].indexOf(env) > -1;
 
 var app = new EmberApp({
   fingerprint: {
+    enabled: isProductionLikeBuild,
     prepend: 'https://subdomain.cloudfront.net/'
   },
+  sourcemaps: {
+    enabled: !isProductionLikeBuild,
+  },
+  minifyCSS: { enabled: isProductionLikeBuild },
+  minifyJS: { enabled: isProductionLikeBuild },
 
-  minifyAssets: { enabled: isProductionLikeBuild },
+  tests: process.env.EMBER_CLI_TEST_COMMAND || !isProductionLikeBuild,
+  hinting: process.env.EMBER_CLI_TEST_COMMAND || !isProductionLikeBuild,
 
-  minifyJS: { enabled: isProductionLikeBuild }
+  vendorFiles: {
+    'handlebars.js': {
+      staging:  'bower_components/handlebars/handlebars.runtime.js'
+    },
+    'ember.js': {
+      staging:  'bower_components/ember/ember.prod.js'
+    }
+  }
 });
 ```
 


### PR DESCRIPTION
I understand stuff is changing real soon with #59 but I was struggling with getting staging setup to behave exactly like production in terms of fingerprinting, minifying etc right now.

There are a number of other options that are required in ember-cli if a build exactly the same as `--environment production` is desired, which i've now added to the readme.