### PR TITLE
Provide better error support for missing environment config

### DIFF
--- a/lib/utilities/configuration-reader.js
+++ b/lib/utilities/configuration-reader.js
@@ -1,16 +1,18 @@
-var path      = require('path');
-var deprecate = require('./deprecate');
-var Config    = require('../models/config');
+var path        = require('path');
+var deprecate   = require('./deprecate');
+var Config      = require('../models/config');
+var SilentError = require('ember-cli/lib/errors/silent');
 
 function ConfigurationReader(options) {
   var root              = process.cwd();
   var defaultConfigPath = path.join('config', 'deploy.js');
+  var environmentConfig;
 
-  this._options = options || {};
-  this._environment = this._options.environment || 'development';
+  this._options      = options || {};
+  this._environment  = this._options.environment || 'development';
   this._deployConfig = this._options.configFile || defaultConfigPath;
 
-  var ui = options.ui;
+  var ui      = options.ui;
   var project = options.project;
 
   deprecate(
@@ -18,6 +20,7 @@ function ConfigurationReader(options) {
     /\.json$/.test(this._options.configFile),
     ui
   );
+
   try {
     var pathToConfig = path.join(root, this._deployConfig);
     this._config = require(pathToConfig);
@@ -26,9 +29,17 @@ function ConfigurationReader(options) {
     throw new Error('Cannot load configuration file \'' + pathToConfig + '\'. Note that the default location of the ember-cli-deploy config file is now \''+ defaultConfigPath + '\'');
   }
 
+  environmentConfig = this._config[this._environment];
+
+  if (!environmentConfig) {
+    throw new SilentError('You are using the `' + this._environment + '` environment but have not specified any configuration.' +
+      '\n\nPlease add a `' + this._environment + '` section to your `config/deploy.js` file.' +
+      '\n\nFor more information, go to: `https://github.com/ember-cli/ember-cli-deploy#config-file`');
+  }
+
   this.config = new Config({
     project: project,
-    rawConfig: this._config[this._environment]
+    rawConfig: environmentConfig
   });
 }
 

--- a/node-tests/unit/utilities/configuration-reader-test.js
+++ b/node-tests/unit/utilities/configuration-reader-test.js
@@ -90,6 +90,19 @@ describe('ConfigurationReader', function() {
         });
       }).to.throw('Cannot load configuration file \'' + path.join(root, configPath) + '\'. Note that the default location of the ember-cli-deploy config file is now \'config/deploy.js\'');
     });
+
+    it('raises an error if a config doesn\'t exist for the current environment', function() {
+      var configPath = './node-tests/fixtures/config/deploy.js';
+
+      expect(function() {
+        new ConfigurationReader({
+          configFile: configPath,
+          ui: ui,
+          project: project,
+          environment: 'non-existent-env'
+        });
+      }).to.throw(/You are using the `non-existent-env` environment/);
+    });
   });
 
   describe('store settings', function() {


### PR DESCRIPTION
This PR will add better messaging when a user tries to run an `ember-cli-deploy` command for an environment for which there exists no configuration.  This most commonly manifests itself when a user does not supply an `--environment` option, running in the default `development` env for which they have not provided config.

This PR explains what the problem is and points the user to the README for more info.

Closes #101 