### PR TITLE
[WIP] Integration test through commonly used plugins

### DIFF
--- a/lib/utilities/adapter-registry.js
+++ b/lib/utilities/adapter-registry.js
@@ -46,6 +46,8 @@ module.exports = CoreObject.extend({
     var adaptersToLoadForTest = process.env['LOAD_ADAPTERS'];
     if (!adaptersToLoadForTest) { return; }
 
+    this.adapters['assets']['null-adapter'] = CoreObject.extend({ upload: function () {} });
+
     adaptersToLoadForTest.split(',').forEach(function (adapterName) {
       var root = this.project.root;
       var addonPath = path.join(root, 'node_modules/' + adapterName);

--- a/lib/utilities/adapter-registry.js
+++ b/lib/utilities/adapter-registry.js
@@ -1,13 +1,17 @@
+/* jshint node: true */
 var CoreObject     = require('core-object');
 var UnknownAdapter = require('./assets/unknown');
 var ShaAdapter     = require('./tagging/sha');
 var merge          = require('lodash-node/modern/objects/merge');
+var Addon = require('ember-cli/lib/models/addon');
+var path = require('path');
 
 module.exports = CoreObject.extend({
   init: function() {
     if (!this.project) { return; }
 
     this.project.addons.forEach(this._mergeDeployAdapters.bind(this));
+    this._addAdaptersForTesting();
   },
 
   lookup: function(type, adapterName) {
@@ -36,5 +40,34 @@ module.exports = CoreObject.extend({
     if (addon.type === 'ember-deploy-addon') {
       this.adapters = merge(this.adapters, addon.adapters);
     }
+  },
+
+  _addAdaptersForTesting: function () {
+    var adaptersToLoadForTest = process.env['LOAD_ADAPTERS'];
+    if (!adaptersToLoadForTest) { return; }
+
+    adaptersToLoadForTest.split(',').forEach(function (adapterName) {
+      var root = this.project.root;
+      var addonPath = path.join(root, 'node_modules/' + adapterName);
+      var AddonConstructor = Addon.lookup({
+        path: addonPath,
+        pkg: require(path.join(addonPath, 'package.json'))
+      });
+
+      var addon = this._createAndVerifyAddonForTesting(AddonConstructor);
+      this._mergeDeployAdapters(addon);
+    }.bind(this));
+  },
+
+  _createAndVerifyAddonForTesting: function (AddonConstructor) {
+    var addon = new AddonConstructor(this.project);
+    if (addon.type !== 'ember-deploy-addon') {
+      throw new Error('package of type ' + addon.type + ' must be `ember-cli-deploy`');
+    }
+    var pkgKeywords = addon.pkg.keywords || [];
+    if (pkgKeywords.indexOf('ember-addon') === -1) {
+      throw new Error("addon must include `ember-addon` in it's keywords");
+    }
+    return addon;
   }
 });

--- a/node-tests/fixtures/config/ember-deploy-redis.js
+++ b/node-tests/fixtures/config/ember-deploy-redis.js
@@ -1,0 +1,12 @@
+module.exports = {
+  "test": {
+    "store": {
+      "type": "redis",
+      "host": "localhost",
+      "port": 6379
+    },
+    "assets": {
+      "type": "null-adapter"
+    }
+  }
+};

--- a/node-tests/plugin-integration/ember-deploy-redis-test.js
+++ b/node-tests/plugin-integration/ember-deploy-redis-test.js
@@ -1,0 +1,40 @@
+/* jshint expr:true */
+var fs = require('fs');
+var syncExec = require('sync-exec');
+var expect = require('chai').expect;
+var redis = require('then-redis');
+
+var resetRedis = function () {
+  var client = redis.createClient({ host: 'localhost', port: 6379 });
+
+  return client.lrange('ember-cli-deploy', 0, 10).then(function (k) {
+    return client.del.apply(client, k);
+  });
+};
+
+var verifyUpload = function () {
+  var client = redis.createClient({ host: 'localhost', port: 6379 });
+  return client.lrange('ember-cli-deploy', 0, 100).then(function (k) {
+    return client.get(k[0]);
+  }).then(function (v) {
+    var indexContents = fs.readFileSync('dist/index.html');
+    expect(v).to.equal(indexContents.toString());
+  });
+};
+
+describe('uploading the index', function () {
+  it('stores the index in redis', function (done) {
+    this.timeout(30 * 1000);
+    var result = syncExec("npm install ember-deploy-redis");
+    expect(result.stderr).to.equal('');
+    resetRedis().then(function () {
+      var config = '--deploy-config-file node-tests/fixtures/config/ember-deploy-redis.js';
+      var command = "LOAD_ADAPTERS=ember-deploy-redis EMBER_VERBOSE_ERRORS=true " +
+        "ember deploy " + config + " --environment test";
+      var commandResult = syncExec(command);
+      expect(commandResult.stderr).to.equal('');
+
+      verifyUpload().then(done, done);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "express": "^4.8.5",
     "github": "0.2.3",
     "mocha": "^2.0.1",
-    "sinon": "^1.12.1"
+    "redis": "^0.12.1",
+    "sinon": "^1.12.1",
+    "then-redis": "^1.3.0"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
In order to help prevent breaking some of the most used plugins and help identify issues with using commonly used plugins as ember-cli-deploy changes, these tests will serve as details of how configurations work along with passing tests to identify breakages.

Items of note currently in flight or in the future

* Need to support running the "plugin-integration" tests outside of normal `npm test` command as these tests will require quite a bit of env setup
* Currently I opted to simply `npm install` the plugin vs including it in the package.json. Alternatively, I thought about creating a set of package.json files to use with these tests. That does open up quite a few rabbit holes however going down one off package.json files. I tried to limit what is included in the current package.json for ember-deploy-cli because node and dependencies. Also, that would be alot to maintain.
* leveraging existing ember app in test/app for this to work and deploy.

Have quite a bit of cleanup but here's are first pass. I'll most likely need to update the travis.yml file to provide redis access.