### PR TITLE
Stub active, list, createTag UnknownAdapter methods

### DIFF
--- a/lib/utilities/assets/unknown.js
+++ b/lib/utilities/assets/unknown.js
@@ -2,10 +2,15 @@ var Adapter     = require('../adapter');
 var Promise     = require('ember-cli/lib/ext/promise');
 var SilentError = require('ember-cli/lib/errors/silent');
 
+var errorMessage = function() {
+  var errorMessage = 'You tried to use an unknown adapter: `' + this.name +
+    '`. Please pass a supported adapter-type.';
+  return Promise.reject(new SilentError(errorMessage));
+}
+
 module.exports = Adapter.extend({
-  upload: function() {
-    var errorMessage = 'You tried to use an unknown adapter: `' + this.name +
-                       '`. Please pass a supported adapter-type.';
-    return Promise.reject(new SilentError(errorMessage));
-  }
+  upload: errorMessage,
+  activate: errorMessage,
+  list: errorMessage,
+  createTag: errorMessage
 });

--- a/node-tests/unit/utilities/assets/unknown-test.js
+++ b/node-tests/unit/utilities/assets/unknown-test.js
@@ -6,29 +6,19 @@ chai.use(chaiAsPromised);
 
 var expect = chai.expect;
 
+var methodTest = function(adapter, method) {
+  return function() {
+    it('rejects to print out an error message', function() {
+      expect(adapter[method]()).to.be.rejected;
+    });
+  };
+}
+
 describe('UnknownAdapter', function() {
-  describe('#upload', function() {
-    it('rejects to print out an error message', function(){
-      unknown = new UnknownAdapter();
-      expect(unknown.upload()).to.be.rejected;
-    });
-  });
-  describe('#activate', function() {
-    it('rejects to print out an error message', function(){
-      unknown = new UnknownAdapter();
-      expect(unknown.activate()).to.be.rejected;
-    });
-  });
-  describe('#list', function() {
-    it('rejects to print out an error message', function(){
-      unknown = new UnknownAdapter();
-      expect(unknown.list()).to.be.rejected;
-    });
-  });
-  describe('#createTag', function() {
-    it('rejects to print out an error message', function(){
-      unknown = new UnknownAdapter();
-      expect(unknown.createTag()).to.be.rejected;
-    });
-  });
+  var adapter = new UnknownAdapter();
+
+  describe('#upload', methodTest(adapter, "upload"));
+  describe('#activate', methodTest(adapter, "activate"));
+  describe('#list', methodTest(adapter, "list"));
+  describe('#createTag', methodTest(adapter, "createTag"));
 });

--- a/node-tests/unit/utilities/assets/unknown-test.js
+++ b/node-tests/unit/utilities/assets/unknown-test.js
@@ -12,5 +12,23 @@ describe('UnknownAdapter', function() {
       unknown = new UnknownAdapter();
       expect(unknown.upload()).to.be.rejected;
     });
-  })
+  });
+  describe('#activate', function() {
+    it('rejects to print out an error message', function(){
+      unknown = new UnknownAdapter();
+      expect(unknown.activate()).to.be.rejected;
+    });
+  });
+  describe('#list', function() {
+    it('rejects to print out an error message', function(){
+      unknown = new UnknownAdapter();
+      expect(unknown.list()).to.be.rejected;
+    });
+  });
+  describe('#createTag', function() {
+    it('rejects to print out an error message', function(){
+      unknown = new UnknownAdapter();
+      expect(unknown.createTag()).to.be.rejected;
+    });
+  });
 });


### PR DESCRIPTION
While developing an index adapter (more on that later), I was getting an unhelpful message;

```
undefined is not a function
TypeError: undefined is not a function
```

This is was because the AdapterRegistry was defaulting to the UnknownAdapter. However unknown adapter was missing the `list` method, so I had to do some manual debugging before I could find it.