### PR TITLE
[DOCUMENTATION] Make Sinatra example a bit more secure

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ require 'redis'
 
 def bootstrap_index(index_key)
   redis = Redis.new
-  index_key ||= redis.get('<your-project-name>:current')
+  index_key &&= "<your-project-name>:#{index_key}"
+  index_key ||= redis.get("<your-project-name>:current")
   redis.get(index_key)
 end
 


### PR DESCRIPTION
I know it's just an example and that real code should have more
checking, but people often copy examples verbatim and I wouldn't
want to read a blog post in the future about this cool trick that
lets you read arbitrary redis keys for most apps deployed via
ember-cli-deploy.

The current example allows users to view any key in redis by
passing an appropriate index_key parameter. This is obviously not
desirable. The amendment I propose isn't 100% secure--it's still
possible to read information that happens to have the same prefix
as the manifest. Ideally one would additionally check to see if
the provided index_key existed in the revisions list before
serving it.

While I could update the example to do this check as well, I worry
that doing so would make the example significantly more complicated
and would obscure what is going on.