### PR TITLE
Index Adapter support for multiple files

### DIFF
--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -49,6 +49,7 @@ module.exports = CoreObject.extend({
       'manifestPrefix': this.project.name(),
       'store.manifestSize': 10,
       'store.type': 'redis',
+      'indexFiles': null,
       'tagging': 'sha'
     };
   },

--- a/lib/tasks/deploy-index.js
+++ b/lib/tasks/deploy-index.js
@@ -41,10 +41,17 @@ module.exports = Task.extend({
       ui: ui
     });
 
-    return readFile('dist/index.html')
-      .then(function(fileContent) {
-        ui.writeLine(chalk.blue('\nTrying to upload `dist/index.html`...\n'));
-        return deploy.upload(fileContent);
-      });
+    var indexFiles = config.get('indexFiles');
+
+    if(indexFiles) {
+      ui.writeLine(chalk.blue('\nUploading '+indexFiles.length+' files from `dist/`...\n'));
+      return deploy.uploadFiles(indexFiles);
+    } else {
+      return readFile('dist/index.html')
+        .then(function(fileContent) {
+          ui.writeLine(chalk.blue('\nUploading `dist/index.html`...\n'));
+          return deploy.upload(fileContent);
+        });
+    }
   }
 });


### PR DESCRIPTION
In our application, we rely on more than just `index.html` for the front end to function. For example, we integrate with Picmonkey, which returns the user to a URL on our site when they have completed the workflow. _(Rather than using `index.html` and loading Ember and other dependencies and have these URLs be additional routes, because we want it to be very fast to load. So these pages contain a very small amount of Javascript, which communicate with the parent frame or window and then close.)_

To support this, we need Index Adapters to allow for more than one file. The existing method works as it did before, by passing the contents of `index.html`. But by setting the `indexFiles` attribute in the deployment config, the index-adapter's `uploadFiles` method is called instead of `upload`. The `uploadFiles` method accepts an array of filenames, each relative to the 'dist/' folder.

No tests yet for this change, because there are no existing tests to modify. So this PR may serve more as an idea seed for upcoming changes in the ember-cli-deploy project.

We are using this interface in our [ember-cli-deploy-redis](https://github.com/ahalogy/ember-cli-deploy-redis) adapter, which also has a [corresponding Rails gem](https://github.com/Ahalogy/ember_cli_deploy_redis_ruby).