### PR TITLE
Default Environment to Staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ By default, `ember-cli-deploy` expects a `deploy.js` file in the `config/` direc
 ```js
 module.exports = {
   development: {
-    buildEnv: 'development', // Override the environment passed to the ember asset build. Defaults to 'production'
+    buildEnv: 'development', // Override the environment passed to the ember asset build. Defaults to 'staging'
     store: {
       type: 'redis', // the default store is 'redis'
       host: 'localhost',
@@ -85,7 +85,6 @@ module.exports = {
   },
 
   staging: {
-    buildEnv: 'staging', // Override the environment passed to the ember asset build. Defaults to 'production'
     store: {
       host: 'staging-redis.example.com',
       port: 6379
@@ -98,6 +97,7 @@ module.exports = {
   },
 
    production: {
+    buildEnv: 'production', // Override the environment passed to the ember asset build. Defaults to 'staging'
     store: {
       host: 'production-redis.example.com',
       port: 6379,

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -45,7 +45,7 @@ module.exports = CoreObject.extend({
       'assets.gzip': true,
       'assets.gzipExtensions': ['js', 'css', 'svg'],
       'assets.type': 's3',
-      'buildEnv': 'production',
+      'buildEnv': 'staging',
       'manifestPrefix': this.project.name(),
       'store.manifestSize': 10,
       'store.type': 'redis',

--- a/node-tests/unit/models/config-test.js
+++ b/node-tests/unit/models/config-test.js
@@ -22,9 +22,9 @@ describe('Config', function() {
   });
 
   describe('buildEnv', function(){
-    it('defaults to production', function() {
+    it('defaults to staging', function() {
       var config = createConfig('tomster', {});
-      expect(config.get('buildEnv')).to.eq('production');
+      expect(config.get('buildEnv')).to.eq('staging');
     });
     it('allows configuration', function() {
       var config = createConfig('tomster', { buildEnv: 'chocula' });


### PR DESCRIPTION
Hey, 
For security reasons we think it makes more sense for the default
to be staging, to prevent any accidents.  I know it's nice to be able to
just quickly type `ember deploy` and that you still need to activate.
But I think it would be better to make the process more deliberate.

-codercooke