### PR TITLE
Add didFail-hook

### DIFF
--- a/lib/utilities/pipeline.js
+++ b/lib/utilities/pipeline.js
@@ -18,7 +18,7 @@ function Pipeline(hookNames, options) {
     pipelineHooks[hookName] = [];
 
     return pipelineHooks;
-  }, {});
+  }, { didFail: [] });
 }
 
 Pipeline.prototype.register = function(hookName, fn) {
@@ -44,50 +44,77 @@ Pipeline.prototype.execute = function(context) {
 
   var ui            = this._ui;
   var pipelineHooks = this._pipelineHooks;
-  var hookNames     = Object.keys(pipelineHooks);
-
+  var hookNames     = this._deploymentHooks(Object.keys(pipelineHooks));
   ui.write(blue('Executing pipeline\n'));
 
-  return hookNames.reduce(function(promise, hookName) {
-    return promise
-      .then(function(context) {
-        ui.write(blue('|\n'));
-        ui.write(blue('+- ' + hookName + '\n'));
+  return hookNames.reduce(this._addHookExecutionPromiseToPipelinePromiseChain.bind(this, ui), Promise.resolve(context))
+    .then(this._notifyPipelineCompletion.bind(this, ui))
+    .catch(this._handleDeploymentFailure.bind(this, ui, context))
+    .catch(this._abortPipelineExecution.bind(this, ui));
+};
 
-        return context;
-      })
-      .then(this._executeHook.bind(this, hookName));
-  }.bind(this), Promise.resolve(context))
-    .then(function() {
-      ui.write(blue('|\n'));
-      ui.write(blue('Pipeline complete\n'));
-    })
-    .catch(function(error) {
-      ui.write(blue('|\n'));
-      ui.write(red('Pipeline aborted\n'));
-      return Promise.reject();
-    });
+Pipeline.prototype._addHookExecutionPromiseToPipelinePromiseChain = function(ui, promise, hookName) {
+  return promise
+    .then(this._notifyPipelineHookExecution.bind(this, ui, hookName))
+    .then(this._executeHook.bind(this, hookName));
+};
+
+Pipeline.prototype._deploymentHooks = function(hooks) {
+  return hooks.filter(function(hook) {
+    return hook !== 'didFail';
+  });
+};
+
+Pipeline.prototype._handleDeploymentFailure = function(ui, context, error) {
+  ui.write(red('|\n'));
+  ui.write(red('+- didFail\n'));
+  return this._executeHook.bind(this, 'didFail')(context)
+    .then(Promise.reject.bind(this, error));
+};
+
+Pipeline.prototype._abortPipelineExecution = function(ui, error) {
+  ui.write(blue('|\n'));
+  ui.write(red('Pipeline aborted\n'));
+  return Promise.reject();
+};
+
+Pipeline.prototype._notifyPipelineCompletion = function(ui) {
+  ui.write(blue('|\n'));
+  ui.write(blue('Pipeline complete\n'));
+};
+
+Pipeline.prototype._notifyPipelineHookExecution = function(ui, hookName, context) {
+  ui.write(blue('|\n'));
+  ui.write(blue('+- ' + hookName + '\n'));
+
+  return context;
 };
 
 Pipeline.prototype._executeHook = function(hookName, context) {
   var ui            = this._ui;
   var hookFunctions = this._pipelineHooks[hookName];
 
-  return hookFunctions.reduce(function(promise, fnObject) {
-    return promise
-      .then(function(context) {
-        ui.write(blue('|  |\n'));
-        ui.write(blue('|  +- ' + fnObject.name + '\n'));
-        return fnObject.fn(context);
-      })
-      .then(function(result) {
-        return _.merge(context, result, function(a, b) {
-          if (_.isArray(a)) {
-            return a.concat(b);
-          }
-        });
-      })
-  }, Promise.resolve(context));
-}
+  return hookFunctions.reduce(this._addPluginHookExecutionPromiseToHookPromiseChain.bind(this, ui, context), Promise.resolve(context));
+};
+
+Pipeline.prototype._addPluginHookExecutionPromiseToHookPromiseChain = function(ui, context, promise, fnObject) {
+  return promise
+    .then(this._notifyPipelinePluginHookExecution.bind(this, ui, fnObject))
+    .then(this._mergePluginHookResultIntoContext.bind(this, context));
+};
+
+Pipeline.prototype._notifyPipelinePluginHookExecution = function(ui, fnObject, context) {
+  ui.write(blue('|  |\n'));
+  ui.write(blue('|  +- ' + fnObject.name + '\n'));
+  return fnObject.fn(context);
+};
+
+Pipeline.prototype._mergePluginHookResultIntoContext = function(context,result) {
+  return _.merge(context, result, function(a, b) {
+    if (_.isArray(a)) {
+      return a.concat(b);
+    }
+  });
+};
 
 module.exports = Pipeline;


### PR DESCRIPTION
Some plugins need the ability to react to failures in the deployment
pipeline to for example notify some webservice of the failed deployment.

It is now possible to add a `didFail`-hook to a plugin that gets
executed as soon as a deployment-hook's execution promise rejects.

* add didFail-hook to pipeline
* 'deanonymize' functions in pipeline utility class