### PR TITLE
Fix _materialize using wrong this context

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -2,7 +2,7 @@ module.exports = {
   "development": {
     "store": {
       "host": "localhost",
-      "port": 6379
+      "port": 63790
     },
     "assets": {
       "accessKeyId": "<your-access-key-goes-here>",
@@ -21,7 +21,8 @@ module.exports = {
       "accessKeyId": "<your-access-key-goes-here>",
       "secretAccessKey": "<your-secret-access-key-goes-here>",
       "bucket": "<your-bucket-name>",
-      "prefix": "<optional-remote-prefix>"
+      "prefix": "<optional-remote-prefix>",
+      "gzipExtensions": ["js", "css", "svg", "json"]
     }
   }
 }

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -62,7 +62,7 @@ module.exports = CoreObject.extend({
     var materialized = JSON.parse(JSON.stringify(this._config));
     var defaultPropertyPaths = this._defaultPropertyPaths;
     Object.keys(defaultPropertyPaths).forEach(function(propertyPath){
-      if (!getPath(this._config, propertyPath)) {
+      if (!getPath(materialized, propertyPath)) {
         setPath(materialized, propertyPath, defaultPropertyPaths[propertyPath]);
       }
     });

--- a/node-tests/fixtures/config-with-defaults/deploy.js
+++ b/node-tests/fixtures/config-with-defaults/deploy.js
@@ -1,0 +1,46 @@
+module.exports = {
+  "development": {
+    "buildEnv": "production",
+    "indexFiles": null,
+    "manifestPrefix": "foo",
+    "tagging": "sha",
+    "store": {
+      "host": "localhost",
+      "manifestSize": 10,
+      "port": 63790,
+      "type": "redis"
+    },
+    "assets": {
+      "accessKeyId": "<your-access-key-goes-here>",
+      "secretAccessKey": "<your-secret-access-key-goes-here>",
+      "bucket": "<your-bucket-name>",
+      "exclude": [],
+      "gzip": true,
+      "gzipExtensions": ["js", "css", "svg"],
+      "type": "s3"
+    }
+  },
+
+  "staging": {
+    "buildEnv": "staging",
+    "indexFiles": null,
+    "manifestPrefix": "foo",
+    "tagging": "sha",
+    "store": {
+      "host": "staging-redis.firstiwaslike.com",
+      "manifestSize": 10,
+      "port": 6379,
+      "type": "redis"
+    },
+    "assets": {
+      "accessKeyId": "<your-access-key-goes-here>",
+      "secretAccessKey": "<your-secret-access-key-goes-here>",
+      "bucket": "<your-bucket-name>",
+      "exclude": [],
+      "gzip": true,
+      "prefix": "<optional-remote-prefix>",
+      "gzipExtensions": ["js", "css", "svg", "json"],
+      "type": "s3"
+    }
+  }
+}

--- a/node-tests/fixtures/config/deploy.js
+++ b/node-tests/fixtures/config/deploy.js
@@ -2,7 +2,7 @@ module.exports = {
   "development": {
     "store": {
       "host": "localhost",
-      "port": 6379
+      "port": 63790
     },
     "assets": {
       "accessKeyId": "<your-access-key-goes-here>",
@@ -20,7 +20,8 @@ module.exports = {
       "accessKeyId": "<your-access-key-goes-here>",
       "secretAccessKey": "<your-secret-access-key-goes-here>",
       "bucket": "<your-bucket-name>",
-      "prefix": "<optional-remote-prefix>"
+      "prefix": "<optional-remote-prefix>",
+      "gzipExtensions": ["js", "css", "svg", "json"]
     }
   }
 }

--- a/node-tests/unit/utilities/configuration-reader-test.js
+++ b/node-tests/unit/utilities/configuration-reader-test.js
@@ -143,5 +143,26 @@ describe('ConfigurationReader', function() {
         expect(config.get('assets')).to.deep.equal(expected);
       });
     });
+  });
+
+  describe('materialized settings', function() {
+    it('proxies the materialized settings for the passed environment', function() {
+      var ENVs    = ['development', 'staging'];
+      var root    = process.cwd();
+      var cfgFile = require(path.join(root, './node-tests/fixtures/config-with-defaults/deploy.js'));
+
+      ENVs.forEach(function(ENV) {
+        var expected = cfgFile[ENV];
+
+        var config = new ConfigurationReader({
+          environment: ENV,
+          ui: ui,
+          project: project
+        }).config;
+
+        expect(config._materialize()).to.deep.equal(expected);
+      });
+    });
   })
+
 });


### PR DESCRIPTION
This bug was causing custom config options that had defaults to not be used within assets tasks (such as ember-deploy-s3).

See https://github.com/ember-cli/ember-cli-deploy/blob/6b96fe989a24566f80df6a06596678b02d5a45aa/lib/tasks/assets.js#L55
and https://github.com/ember-cli/ember-cli-deploy/blob/6b96fe989a24566f80df6a06596678b02d5a45aa/lib/models/config.js#L44-55