### PR TITLE
Only register initialised hooks

### DIFF
--- a/lib/tasks/pipeline.js
+++ b/lib/tasks/pipeline.js
@@ -105,18 +105,17 @@ module.exports = Task.extend({
 
     var deployPlugin = addon.createDeployPlugin({name: name});
 
-    Object.keys(deployPlugin).forEach(function(key) {
-      var fn        = deployPlugin[key];
-      var isPrivate = this._isPrivateProperty(key);
-      var hookName  = (typeof deployPlugin.name === 'function') ? deployPlugin.name() : deployPlugin.name;
+    this._hookNames().forEach(function(hookName) {
+      var fn         = deployPlugin[hookName];
+      var pluginName = (typeof deployPlugin.name === 'function') ? deployPlugin.name() : deployPlugin.name;
 
-      if (!isPrivate && (typeof fn === 'function')) {
+      if (typeof fn === 'function') {
         var fnObject = {
-          name: hookName,
+          name: pluginName,
           fn: fn.bind(deployPlugin)
         };
 
-        this._pipeline.register(key, fnObject);
+        this._pipeline.register(hookName, fnObject);
       }
     }.bind(this));
   },
@@ -129,8 +128,8 @@ module.exports = Task.extend({
     return hasDeployKeyword && implementsDeploymentHooks;
   },
 
-  _isPrivateProperty: function(propertyName) {
-    return propertyName.charAt(0) === '_';
+  _hookNames: function() {
+    return this._pipeline.hookNames();
   }
 });
 

--- a/lib/utilities/pipeline.js
+++ b/lib/utilities/pipeline.js
@@ -32,9 +32,9 @@ Pipeline.prototype.register = function(hookName, fn) {
     };
   }
 
-  ui.write(blue('Registering hook -> ' + hookName + '[' + fn.name + ']\n'));
-
   if (pipelineHooks[hookName]) {
+    ui.write(blue('Registering hook -> ' + hookName + '[' + fn.name + ']\n'));
+
     pipelineHooks[hookName].push(fn);
   }
 };

--- a/lib/utilities/pipeline.js
+++ b/lib/utilities/pipeline.js
@@ -42,15 +42,18 @@ Pipeline.prototype.register = function(hookName, fn) {
 Pipeline.prototype.execute = function(context) {
   context = context || { };
 
-  var ui            = this._ui;
-  var pipelineHooks = this._pipelineHooks;
-  var hookNames     = this._deploymentHooks(Object.keys(pipelineHooks));
+  var ui = this._ui;
   ui.write(blue('Executing pipeline\n'));
 
-  return hookNames.reduce(this._addHookExecutionPromiseToPipelinePromiseChain.bind(this, ui), Promise.resolve(context))
+  return this._deploymentHooks(this.hookNames())
+    .reduce(this._addHookExecutionPromiseToPipelinePromiseChain.bind(this, ui), Promise.resolve(context))
     .then(this._notifyPipelineCompletion.bind(this, ui))
     .catch(this._handleDeploymentFailure.bind(this, ui, context))
     .catch(this._abortPipelineExecution.bind(this, ui));
+};
+
+Pipeline.prototype.hookNames = function() {
+  return Object.keys(this._pipelineHooks);
 };
 
 Pipeline.prototype._addHookExecutionPromiseToPipelinePromiseChain = function(ui, promise, hookName) {

--- a/node-tests/unit/utilities/pipeline-test.js
+++ b/node-tests/unit/utilities/pipeline-test.js
@@ -157,4 +157,14 @@ describe ('Pipeline', function() {
         });
     });
   });
+
+  describe('#hookNames', function() {
+    it('returns the names of the registered hooks', function() {
+      var subject = new Pipeline(['hook1', 'hook2']);
+
+      var result = subject.hookNames();
+
+      expect(result).to.have.members(['hook1', 'hook2', 'didFail']);
+    });
+  });
 });


### PR DESCRIPTION
Previous to this PR we would loop through all keys on the deploy plugin object and register the functions.  This could be error prone.  Instead we now cycle through the list of hooks that the pipeline has been initialised with and then retrieve them from the deploy plugin