### PR TITLE
Add ability to configure build paths, defaulting to tmp/deploy-dist/.

### DIFF
--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -26,11 +26,11 @@ module.exports = {
       ui: this.ui,
       analytics: this.analytics,
       project: this.project
-
     });
+
     var buildOptions = {
       environment: config.get('buildEnv'),
-      outputPath: "dist/",
+      outputPath: config.get('buildPath'),
       watch: false,
       disableAnalytics: false
     };

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -47,6 +47,7 @@ module.exports = CoreObject.extend({
       'assets.type': 's3',
       'assets.exclude': [],
       'buildEnv': 'production',
+      'buildPath': 'tmp/deploy-dist/',
       'manifestPrefix': this.project.name(),
       'store.manifestSize': 10,
       'store.type': 'redis',

--- a/lib/tasks/assets.js
+++ b/lib/tasks/assets.js
@@ -21,11 +21,11 @@ module.exports = Task.extend({
 
     var fileTreeOrPath;
     if (config.get('assets.gzip') === false) {
-      fileTreeOrPath = 'dist';
+      fileTreeOrPath = config.get('buildPath');
     } else {
       var gzipFiles = require('broccoli-gzip');
 
-      fileTreeOrPath = gzipFiles('dist', {
+      fileTreeOrPath = gzipFiles(config.get('buildPath'), {
         extensions: config.get('assets.gzipExtensions'),
         appendSuffix: false
       });

--- a/lib/tasks/deploy-index.js
+++ b/lib/tasks/deploy-index.js
@@ -44,12 +44,12 @@ module.exports = Task.extend({
     var indexFiles = config.get('indexFiles');
 
     if(indexFiles) {
-      ui.writeLine(chalk.blue('\nUploading '+indexFiles.length+' files from `dist/`...\n'));
+      ui.writeLine(chalk.blue('\nUploading '+indexFiles.length+' files from `'+config.get('buildPath')+'`...\n'));
       return deploy.uploadFiles(indexFiles);
     } else {
-      return readFile('dist/index.html')
+      return readFile(config.get('buildPath')+'index.html')
         .then(function(fileContent) {
-          ui.writeLine(chalk.blue('\nUploading `dist/index.html`...\n'));
+          ui.writeLine(chalk.blue('\nUploading `'+config.get('buildPath')+'index.html`...\n'));
           return deploy.upload(fileContent);
         });
     }

--- a/node-tests/unit/models/config-test.js
+++ b/node-tests/unit/models/config-test.js
@@ -32,6 +32,17 @@ describe('Config', function() {
     });
   });
 
+  describe('buildPath', function(){
+    it('defaults to tmp/deploy-dist/', function() {
+      var config = createConfig('tomster', {});
+      expect(config.get('buildPath')).to.eq('tmp/deploy-dist/');
+    });
+    it('allows configuration', function() {
+      var config = createConfig('tomster', { buildPath: 'hamsterwheel' });
+      expect(config.get('buildPath')).to.eq('hamsterwheel');
+    });
+  });
+
   describe('store.type', function(){
     it('defaults to redis', function() {
       var config = createConfig('tomster', {});


### PR DESCRIPTION
By default this prevents problems occuring when running both `ember deploy` and `ember serve` (#134).
Includes unit tests showing configurability.