### PR TITLE
Adds support for “plugin packs” to 0.5.0

### DIFF
--- a/lib/tasks/pipeline.js
+++ b/lib/tasks/pipeline.js
@@ -94,6 +94,16 @@ module.exports = Task.extend({
   },
 
   _registerPipelineHooks: function(addon, configuredPluginList) {
+    var self = this;
+
+    var isDeployPluginPack = this._isDeployPluginPack(addon);
+    if (isDeployPluginPack) {
+      addon.addons.forEach(function(nestedAddon){
+        self._registerPipelineHooks(nestedAddon, configuredPluginList);
+      });
+      return;
+    }
+
     var isValidDeployPlugin = this._isValidDeployPlugin(addon);
     if (!isValidDeployPlugin) { return; }
 
@@ -118,6 +128,11 @@ module.exports = Task.extend({
         this._pipeline.register(hookName, fnObject);
       }
     }.bind(this));
+  },
+
+  _isDeployPluginPack: function(addon) {
+    var keywords = addon.pkg.keywords;
+    return keywords.indexOf('ember-cli-deploy-plugin-pack') > -1;
   },
 
   _isValidDeployPlugin: function(addon) {

--- a/node-tests/unit/tasks/pipeline-test.js
+++ b/node-tests/unit/tasks/pipeline-test.js
@@ -216,6 +216,57 @@ describe('PipelineTask', function() {
           expect(registeredHooks.upload[0].fn).to.be.a('function');
         });
       });
+      it('registers dependent plugin addons of a plugin pack addon designated by the ember-cli-deploy-plugin-pack keyword', function() {
+        var project = {
+          name: function() {return 'test-project';},
+          root: process.cwd(),
+          addons: [
+            {
+              name: 'ember-cli-deploy-test-plugin-pack',
+              pkg: {
+                keywords: [
+                  'ember-cli-deploy-plugin-pack'
+                ]
+              },
+              addons: [
+                {
+                  name: 'ember-cli-deploy-test-plugin',
+                  pkg: {
+                    keywords: [
+                      'ember-cli-deploy-plugin'
+                    ]
+                  },
+                  createDeployPlugin: function() {
+                    return {
+                      name: 'test-plugin',
+                      willDeploy: function() {},
+                      upload: function() {}
+                    };
+                  }
+                }
+              ]
+            }
+          ]
+        };
+
+        var task = new PipelineTask({
+          project: project,
+          ui: mockUi,
+          deployEnvironment: 'development',
+          deployConfigPath: 'node-tests/fixtures/config/deploy.js',
+          hooks: ['willDeploy', 'upload']
+        });
+        return task.setup().then(function(){
+          var registeredHooks = task._pipeline._pipelineHooks;
+
+          expect(registeredHooks.willDeploy.length).to.eq(1);
+          expect(registeredHooks.willDeploy[0].name).to.eq('test-plugin');
+          expect(registeredHooks.willDeploy[0].fn).to.be.a('function');
+          expect(registeredHooks.upload.length).to.eq(1);
+          expect(registeredHooks.upload[0].name).to.eq('test-plugin');
+          expect(registeredHooks.upload[0].fn).to.be.a('function');
+        });
+      });
     });
   });
 


### PR DESCRIPTION
A plugin pack is an addon with the keyword “ember-cli-deploy-plugin-pack”
and one or more dependent addons that are ember-cli-deploy-plugins.

Note that the plugin pack’s dependent addons should be listed as
dependencies in the pack’s package.json, not as devDependencies.

I expect that plugin packs may also implement a config/deploy.js
blueprint that is auto-executed upon `ember install` of the pack.