### PR TITLE
Manifest prefix for activate task.

### DIFF
--- a/lib/tasks/activate.js
+++ b/lib/tasks/activate.js
@@ -24,7 +24,7 @@ module.exports = Task.extend({
 
     var deploy = new Adapter({
       config: config.get('store'),
-      manifest: this.project.name(),
+      manifest: config.get('manifestPrefix'),
       manifestSize: config.get('store.manifestSize'),
       ui: ui
     });

--- a/lib/tasks/deploy-index.js
+++ b/lib/tasks/deploy-index.js
@@ -19,7 +19,7 @@ module.exports = Task.extend({
 
     var adapterType = config.get('store.type');
     var taggingAdapterType = config.get('tagging');
-    var manifest = this.project.name();
+    var manifest = config.get('manifestPrefix');
 
     var adapterRegistry = new AdapterRegistry({ project: this.project });
 
@@ -30,7 +30,7 @@ module.exports = Task.extend({
       .lookup('tagging', taggingAdapterType)
 
     var taggingAdapter = new TaggingAdapter({
-      manifest: config.get('manifestPrefix')
+      manifest: manifest
     });
 
     var deploy = new Adapter({


### PR DESCRIPTION
Manifest prefix needs to be used for the activate task as well and in all adapters instance.