### PR TITLE
Use silent-error NPM Package

### DIFF
--- a/lib/commands/deprecated/activate.js
+++ b/lib/commands/deprecated/activate.js
@@ -1,6 +1,6 @@
 var chalk = require('chalk');
 var Promise = require('ember-cli/lib/ext/promise');
-var SilentError         = require('ember-cli/lib/errors/silent');
+var SilentError         = require('silent-error');
 var DeprecatedCommand = require('./deprecated-command');
 var ActivateCommand = require('../activate');
 

--- a/lib/tasks/activate.js
+++ b/lib/tasks/activate.js
@@ -3,7 +3,7 @@ var Task                = require('ember-cli/lib/models/task');
 var ConfigurationReader = require('../utilities/configuration-reader');
 var AdapterRegistry     = require('../utilities/adapter-registry');
 var Promise             = require('ember-cli/lib/ext/promise');
-var SilentError         = require('ember-cli/lib/errors/silent');
+var SilentError         = require('silent-error');
 
 var white = chalk.white;
 var green = chalk.green;

--- a/lib/utilities/adapter.js
+++ b/lib/utilities/adapter.js
@@ -1,6 +1,6 @@
 var CoreObject  = require('core-object');
 var Promise     = require('ember-cli/lib/ext/promise');
-var SilentError = require('ember-cli/lib/errors/silent');
+var SilentError = require('silent-error');
 
 module.exports = CoreObject.extend({
   upload: function() {

--- a/lib/utilities/assets/unknown.js
+++ b/lib/utilities/assets/unknown.js
@@ -1,6 +1,6 @@
 var Adapter     = require('../adapter');
 var Promise     = require('ember-cli/lib/ext/promise');
-var SilentError = require('ember-cli/lib/errors/silent');
+var SilentError = require('silent-error');
 
 var errorMessage = function() {
   var errorMessage = 'You tried to use an unknown adapter: `' + this.name +

--- a/lib/utilities/configuration-reader.js
+++ b/lib/utilities/configuration-reader.js
@@ -1,7 +1,7 @@
 var path        = require('path');
 var deprecate   = require('./deprecate');
 var Config      = require('../models/config');
-var SilentError = require('ember-cli/lib/errors/silent');
+var SilentError = require('silent-error');
 
 function ConfigurationReader(options) {
   var root              = process.cwd();

--- a/package.json
+++ b/package.json
@@ -45,16 +45,17 @@
     "ember-cli-deploy"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0",
     "broccoli": "^0.13.2",
     "broccoli-gzip": "^0.2.0",
     "chalk": "^0.5.1",
     "core-object": "0.0.2",
+    "ember-cli-babel": "^5.0.0",
     "glob": "4.4.2",
     "lodash-node": "^2.4.1",
     "mkdirp": "^0.5.0",
     "ncp": "^2.0.0",
     "rimraf": "^2.2.8",
+    "silent-error": "^1.0.0",
     "sync-exec": "^0.5.0"
   }
 }


### PR DESCRIPTION
It was removed from Ember CLI proper, so we'll need to include this
ourselves now.

Resolves #163.

It'd be nice to get this into a bug fix release :)