### PR TITLE
Use SilentError to log errors when parsing config.

### DIFF
--- a/lib/utilities/configuration-reader.js
+++ b/lib/utilities/configuration-reader.js
@@ -26,7 +26,7 @@ function ConfigurationReader(options) {
     this._config = require(pathToConfig);
   } catch(e) {
     ui.writeError(e);
-    throw new Error('Cannot load configuration file \'' + pathToConfig + '\'. Note that the default location of the ember-cli-deploy config file is now \''+ defaultConfigPath + '\'');
+    throw new SilentError('Cannot load configuration file \'' + pathToConfig + '\'. Note that the default location of the ember-cli-deploy config file is now \''+ defaultConfigPath + '\'');
   }
 
   environmentConfig = this._config[this._environment];


### PR DESCRIPTION
The original error and stack is already printed to the console, there is no need to throw a "real" error (because the stack within ember-cli-deploy itself is not useful).