### PR TITLE
[0.5.0] Plugin base class restructure

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -2,6 +2,9 @@ module.exports = function(environment) {
   var ENV = {};
 
   if (environment === 'development') {
+    ENV.build = {
+      environment: 'development'
+    };
     ENV.store = {
       host: 'localhost',
       port: 6379
@@ -15,7 +18,9 @@ module.exports = function(environment) {
   }
 
   if (environment === 'staging') {
-    ENV.buildEnv = 'staging';
+    ENV.build = {
+      environment: 'production'
+    };
 
     ENV.store = {
       host: 'staging-redis.firstiwaslike.com',

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,5 +1,5 @@
 'use strict';
 
-module.exports = function(/* environment, appConfig */) {
+module.exports = function(/* environment */) {
   return { something: 'test' };
 };

--- a/index.js
+++ b/index.js
@@ -36,14 +36,14 @@ Deploy.prototype.blueprintsPath = function() {
 };
 
 Deploy.prototype.included = function(app) {
-  var buildEnv   = this._deployEnvSetByDeployCommand();
+  var deployEnv  = this._deployEnvSetByDeployCommand();
   var root       = app.project.root;
   var configPath = path.join(root, 'config', 'deploy');
   var config;
   var fingerprint;
 
-  if (buildEnv) {
-    config = require(configPath)(buildEnv);
+  if (deployEnv) {
+    config = require(configPath)(deployEnv);
 
     if (config.fingerprint === false) {
       app.options.fingerprint = {enabled: false};

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -46,7 +46,7 @@ module.exports = CoreObject.extend({
       'assets.gzipExtensions': ['js', 'css', 'svg'],
       'assets.type': 's3',
       'assets.exclude': [],
-      'buildEnv': 'production',
+      'build.environment': 'production',
       'buildPath': 'tmp/deploy-dist/',
       'manifestPrefix': this.project.name(),
       'store.manifestSize': 10,

--- a/lib/tasks/pipeline.js
+++ b/lib/tasks/pipeline.js
@@ -37,24 +37,19 @@ module.exports = Task.extend({
     }
 
     this.deployConfigPath  = this.deployConfigPath || 'config/deploy.js';
-    this.appConfigPath        = 'config/environment.js';
 
     if (!existsSync(this.deployConfigPath)) {
       throw new SilentError('Deploy config does not exist at `' + this.deployConfigPath + '`');
-    }
-
-    if (!existsSync(this.appConfigPath)) {
-      throw new SilentError('App config does not exist at `' + this.appConfigPath + '`');
     }
   },
 
   setup: function(){
     var self = this;
-    return this._readConfig().then(function(configs){
+    return this._readConfig().then(function(deployConfig){
       self.project.addons.forEach(function(addon){
-        self._registerPipelineHooks(addon, configs.deployConfig.plugins);
+        self._registerPipelineHooks(addon, deployConfig.plugins);
       });
-      return configs;
+      return deployConfig;
     });
   },
 
@@ -65,11 +60,10 @@ module.exports = Task.extend({
     var self            = this;
     var commandLineArgs = this.commandLineArgs;
 
-    return this.setup().then(function(configs){
+    return this.setup().then(function(deployConfig){
       var context = {
-        appConfig: configs.appConfig,
         commandLineArgs: commandLineArgs,
-        config: configs.deployConfig,
+        config: deployConfig,
         deployEnvironment: self.deployEnvironment,
         project: project,
         ui: ui
@@ -82,16 +76,8 @@ module.exports = Task.extend({
 
   _readConfig: function() {
     var project         = this.project;
-    var appConfigPath   = this.appConfigPath;
     var deployConfigFn  = require(path.join(project.root, this.deployConfigPath));
-    return Promise.resolve(deployConfigFn(this.deployEnvironment)).then(function(deployConfig){
-      var buildEnv = (deployConfig.build && deployConfig.build.buildEnv) || 'production';
-      var appConfigFn = require(path.join(project.root, appConfigPath));
-      return {
-        deployConfig: deployConfig,
-        appConfig: appConfigFn(buildEnv)
-      };
-    });
+    return Promise.resolve(deployConfigFn(this.deployEnvironment));
   },
 
   _registerPipelineHooks: function(addon, configuredPluginList) {

--- a/lib/tasks/pipeline.js
+++ b/lib/tasks/pipeline.js
@@ -45,19 +45,19 @@ module.exports = Task.extend({
 
   setup: function(){
     var self = this;
-    return this._readConfig().then(function(deployConfig){
+    return this._readDeployConfig().then(function(deployConfig){
       self.project.addons.forEach(function(addon){
-        self._registerPipelineHooks(addon, deployConfig.plugins);
+        self._registerPipelineHooks(addon, deployConfig);
       });
       return deployConfig;
     });
   },
 
   run: function(hooks) {
+    var self            = this;
     var pipeline        = this._pipeline;
     var ui              = this.ui;
     var project         = this.project;
-    var self            = this;
     var commandLineArgs = this.commandLineArgs;
 
     return this.setup().then(function(deployConfig){
@@ -68,24 +68,23 @@ module.exports = Task.extend({
         project: project,
         ui: ui
       };
-      return pipeline.execute({
-        deployment: context
-      });
+      return pipeline.execute(context);
     });
   },
 
-  _readConfig: function() {
+  _readDeployConfig: function() {
     var project         = this.project;
     var deployConfigFn  = require(path.join(project.root, this.deployConfigPath));
     return Promise.resolve(deployConfigFn(this.deployEnvironment));
   },
 
-  _registerPipelineHooks: function(addon, configuredPluginList) {
+  _registerPipelineHooks: function(addon, deployConfig) {
     var self = this;
+    var configuredPluginList = deployConfig.plugins;
 
     if (this._isDeployPluginPack(addon)) {
       addon.addons.forEach(function(nestedAddon){
-        self._registerPipelineHooks(nestedAddon, configuredPluginList);
+        self._registerPipelineHooks(nestedAddon, deployConfig);
       });
       return;
     }
@@ -99,7 +98,6 @@ module.exports = Task.extend({
     }
 
     var deployPlugin = addon.createDeployPlugin({name: name});
-    var pluginName = this._getPluginName(deployPlugin);
 
     this._pipeline.hookNames().forEach(function(hookName) {
       var fn = deployPlugin[hookName];
@@ -108,8 +106,13 @@ module.exports = Task.extend({
       }
 
       this._pipeline.register(hookName, {
-        name: pluginName,
-        fn: fn.bind(deployPlugin)
+        name: deployPlugin.name,
+        fn: function(context){
+          if (deployPlugin.beforeHook &&  typeof deployPlugin.beforeHook === 'function') {
+            deployPlugin.beforeHook(context);
+          }
+          return fn.call(deployPlugin, context);
+        }
       });
     }.bind(this));
   },
@@ -130,14 +133,6 @@ module.exports = Task.extend({
 
   _addonImplementsDeploymentHooks: function(addon) {
     return addon.createDeployPlugin && typeof addon.createDeployPlugin === 'function';
-  },
-
-  _getPluginName: function(plugin) {
-    if (typeof plugin.name === 'function') {
-      return plugin.name();
-    } else {
-      return plugin.name;
-    }
   }
 });
 

--- a/lib/utilities/pipeline.js
+++ b/lib/utilities/pipeline.js
@@ -61,9 +61,16 @@ Pipeline.prototype.hookNames = function() {
 };
 
 Pipeline.prototype._addHookExecutionPromiseToPipelinePromiseChain = function(ui, promise, hookName) {
+  var self = this;
   return promise
-    .then(this._notifyPipelineHookExecution.bind(this, ui, hookName))
-    .then(this._executeHook.bind(this, hookName));
+  .then(this._notifyPipelineHookExecution.bind(this, ui, hookName))
+  .then(function(context){
+    try {
+      return self._executeHook(hookName, context);
+    } catch(error) {
+      return Promise.reject(error);
+    }
+  });
 };
 
 Pipeline.prototype._hooksWithoutDidFail = function(hooks) {
@@ -75,7 +82,8 @@ Pipeline.prototype._hooksWithoutDidFail = function(hooks) {
 Pipeline.prototype._handlePipelineFailure = function(ui, context, error) {
   ui.write(red('|\n'));
   ui.write(red('+- didFail\n'));
-  return this._executeHook.bind(this, 'didFail')(context)
+  ui.write(red(error + "\n" + (error ? error.stack : null)));
+  return this._executeHook('didFail', context)
     .then(Promise.reject.bind(this, error));
 };
 

--- a/node-tests/fixtures/config-with-defaults/deploy.js
+++ b/node-tests/fixtures/config-with-defaults/deploy.js
@@ -1,6 +1,8 @@
 module.exports = {
   "development": {
-    "buildEnv": "production",
+    "build": {
+      "environment": "development"
+    },
     "buildPath": "tmp/deploy-dist/",
     "indexFiles": null,
     "manifestPrefix": "foo",
@@ -23,7 +25,9 @@ module.exports = {
   },
 
   "staging": {
-    "buildEnv": "staging",
+    "build": {
+      "environment": "production"
+    },
     "buildPath": "tmp/deploy-dist/",
     "indexFiles": null,
     "manifestPrefix": "foo",

--- a/node-tests/unit/models/config-test.js
+++ b/node-tests/unit/models/config-test.js
@@ -24,11 +24,11 @@ describe('Config', function() {
   describe('buildEnv', function(){
     it('defaults to production', function() {
       var config = createConfig('tomster', {});
-      expect(config.get('buildEnv')).to.eq('production');
+      expect(config.get('build.environment')).to.eq('production');
     });
     it('allows configuration', function() {
-      var config = createConfig('tomster', { buildEnv: 'chocula' });
-      expect(config.get('buildEnv')).to.eq('chocula');
+      var config = createConfig('tomster', { build: { environment: 'chocula' } });
+      expect(config.get('build.environment')).to.eq('chocula');
     });
   });
 

--- a/node-tests/unit/tasks/pipeline-test.js
+++ b/node-tests/unit/tasks/pipeline-test.js
@@ -271,7 +271,7 @@ describe('PipelineTask', function() {
   describe('executing the pipeline task', function() {
     it ('executes the pipeline, passing in the deployment context', function() {
       var pipelineExecuted = false;
-      var deployment;
+      var pipelineContext;
 
       var project = {
         name: function() {return 'test-project';},
@@ -289,7 +289,7 @@ describe('PipelineTask', function() {
         pipeline: {
           execute: function(context) {
             pipelineExecuted = true;
-            deployment = context.deployment;
+            pipelineContext = context;
             return Promise.resolve();
           }
         }
@@ -298,11 +298,11 @@ describe('PipelineTask', function() {
       return expect(task.run()).to.be.fulfilled
         .then(function() {
           expect(pipelineExecuted).to.be.true;
-          expect(deployment.ui).to.eq(mockUi);
-          expect(deployment.project).to.eq(project);
-          expect(deployment.deployEnvironment).to.eq('development');
-          expect(deployment.config.build.buildEnv).to.eq('development');
-          expect(deployment.commandLineArgs.revision).to.eq('123abc');
+          expect(pipelineContext.ui).to.eq(mockUi);
+          expect(pipelineContext.project).to.eq(project);
+          expect(pipelineContext.deployEnvironment).to.eq('development');
+          expect(pipelineContext.config.build.buildEnv).to.eq('development');
+          expect(pipelineContext.commandLineArgs.revision).to.eq('123abc');
         });
     });
   });

--- a/node-tests/unit/tasks/pipeline-test.js
+++ b/node-tests/unit/tasks/pipeline-test.js
@@ -6,7 +6,6 @@ var assert       = require('chai').assert;
 describe('PipelineTask', function() {
   var mockProject   = {addons: []};
   var mockConfig    = {};
-  var mockAppConfig = {};
   var mockUi        = { write: function() {} };
 
   describe('creating and setting up a new instance', function() {
@@ -22,8 +21,7 @@ describe('PipelineTask', function() {
       var fn = function() {
         new PipelineTask({
           project: mockProject,
-          config: mockConfig,
-          appConfig: mockAppConfig
+          config: mockConfig
         });
       };
 

--- a/node-tests/unit/utilities/pipeline-test.js
+++ b/node-tests/unit/utilities/pipeline-test.js
@@ -43,7 +43,7 @@ describe ('Pipeline', function() {
   });
 
   describe ('#execute', function() {
-    it ('runs the registered functions', function() {
+    it('runs the registered functions', function() {
       var subject = new Pipeline(['hook1', 'hook2'], {ui: {write: function() {}}});
       var hooksRun = [];
 
@@ -54,7 +54,6 @@ describe ('Pipeline', function() {
       subject.register('hook2', function() {
         hooksRun.push('2');
       });
-
       return expect(subject.execute()).to.be.fulfilled
         .then(function() {
           expect(hooksRun.length).to.eq(2);

--- a/rfc/plugins.md
+++ b/rfc/plugins.md
@@ -92,7 +92,6 @@ of properties that may be of use to a plugin:
 Property | file | info
 --- | --- | ---
 `ui` | - | The ember-cli UI object that can be used to write to stdout.
-`appConfig` | `config/environment.js` | The application configuration.
 `config` | stored in `config/deploy.js` | The configuration portion of `config/deploy.js` for the active environment
 `data` | - | Runtime information about the current operation. Plugins can set properties on this object for later use by themselves or another plugin.
 

--- a/rfc/plugins.md
+++ b/rfc/plugins.md
@@ -83,9 +83,9 @@ property. Usually, the `name` will be the plugin name sans the `ember-cli-deploy
 prefix, unless a name has been specified as described in Advanced Plugin
 Configuration below.
 
-### The `deployment` object
+### The `context` object
 
-For each high-level ember-cli-deploy operation, a `deployment` object is created.
+For each high-level ember-cli-deploy operation, a `context` object is created.
 This object is passed to each hook that is invoked on the plugins. It has a number
 of properties that may be of use to a plugin:
 


### PR DESCRIPTION
Restructure to support plugin base class.

* Removes `deployment` node in favor of moving ui, config, etc properties to top level of "context".
* Invokes `beforeHook` on a plugin (if defined) before each hook is called.

Merge of this should be coordinated with similar named branch among all 0.5.0 plugins.

Plugin PR's to merge:

- [ ] https://github.com/lukemelia/ember-cli-deploy-gzip/pull/3
- [ ] https://github.com/lukemelia/ember-cli-deploy-manifest/pull/4
- [ ] https://github.com/zapnito/ember-cli-deploy-s3/pull/7
- [ ] https://github.com/zapnito/ember-cli-deploy-redis/pull/10 
- [ ] https://github.com/zapnito/ember-cli-deploy-build/pull/12
- [ ] https://github.com/zapnito/ember-cli-deploy-revision-key/pull/10 
- [ ] https://github.com/zapnito/ember-cli-deploy-json-config/pull/8 
- [ ] https://github.com/LevelbossMike/ember-cli-deploy-slack/pull/2 