### PR TITLE
fix failing test on windows caused by path.join returning backslashes…

### DIFF
--- a/node-tests/unit/utilities/configuration-reader-test.js
+++ b/node-tests/unit/utilities/configuration-reader-test.js
@@ -91,7 +91,7 @@ describe('ConfigurationReader', function() {
       }).read().then(function(){
         expect(false).to.equal(true);
       }, function(err){
-        expect(err.message).to.equal('Cannot load configuration file \'' + path.join(root, configPath) + '\'. Note that the default location of the ember-cli-deploy config file is now \'config/deploy.js\'');
+        expect(err.message).to.equal('Cannot load configuration file \'' + path.join(root, configPath) + '\'. Note that the default location of the ember-cli-deploy config file is now \''+ path.join('config', 'deploy.js')+'\'');
       });
     });
 


### PR DESCRIPTION
… for the path