### PR TITLE
[BREAKING] New command line args

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ You must have an entry for every environment you want to use in this file.
 
 This is an example of how one would use this addon to deploy an ember-cli app:
 
-* `ember deploy --environment production`
-* `ember deploy:list --environment production` (this will print out a list of revisions)
-* `ember deploy:activate --revision ember-deploy:44f2f92 --environment production `
+* `ember deploy production`
+* `ember deploy:list production` (this will print out a list of revisions)
+* `ember deploy:activate production --revision 44f2f92`
 
 ## Fingerprinting Options / Staging environments
 

--- a/lib/commands/activate.js
+++ b/lib/commands/activate.js
@@ -4,28 +4,25 @@ module.exports = {
   works: 'insideProject',
 
   availableOptions: [
-    { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
+    { name: 'revision', type: String, required: true },
     { name: 'deploy-config-file', type: String, default: 'config/deploy.js' }
   ],
 
   anonymousOptions: [
-    '<revision>'
+    '<deployTarget>'
   ],
 
   run: function(commandOptions, rawArgs) {
-    process.env.DEPLOY_ENVIRONMENT = commandOptions.environment;
-
-    var commandLineArgs = {
-      revisionKey: rawArgs.shift()
-    };
+    commandOptions.deployTarget = rawArgs.shift()
+    process.env.DEPLOY_TARGET = commandOptions.deployTarget;
 
     var PipelineTask = require('../tasks/pipeline');
     var pipeline = new PipelineTask({
       project: this.project,
       ui: this.ui,
-      deployEnvironment: commandOptions.environment,
+      deployTarget: commandOptions.deployTarget,
       deployConfigPath: commandOptions.deployConfigFile,
-      commandLineArgs: commandLineArgs,
+      commandOptions: commandOptions,
       hooks: [
         'configure',
         'willActivate',

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -6,14 +6,18 @@ module.exports = {
   description: 'Deploys an ember-cli app',
   works: 'insideProject',
 
+  anonymousOptions: [
+    '<deployTarget>'
+  ],
+
   availableOptions: [
-    { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
     { name: 'deploy-config-file', type: String, default: 'config/deploy.js' },
     { name: 'activate', type: Boolean }
   ],
 
   run: function(commandOptions, rawArgs) {
-    process.env.DEPLOY_ENVIRONMENT = commandOptions.environment;
+    commandOptions.deployTarget = rawArgs.shift()
+    process.env.DEPLOY_TARGET = commandOptions.deployTarget;
 
     var shouldActivate = this._shouldActivate(commandOptions);
 
@@ -21,8 +25,9 @@ module.exports = {
     var pipeline = new PipelineTask({
       project: this.project,
       ui: this.ui,
-      deployEnvironment: commandOptions.environment,
+      deployTarget: commandOptions.deployTarget,
       deployConfigPath: commandOptions.deployConfigFile,
+      commandOptions: commandOptions,
       hooks: this._hooks(shouldActivate)
     });
 
@@ -52,10 +57,10 @@ module.exports = {
   },
 
   _pipelineConfig: function(options) {
-    var root     = this.project.root;
+    var root = this.project.root;
     var filePath = options.deployConfigFile;
     var fullPath = path.join(root, filePath);
-    var env      = options.environment;
+    var deployTarget = options.deployTarget;
 
     if (!existsSync(fullPath)) {
       return {};
@@ -63,6 +68,6 @@ module.exports = {
 
     var fn = require(fullPath);
 
-    return fn(env)['pipeline'] || {};
+    return fn(deployTarget)['pipeline'] || {};
   }
 };

--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -3,8 +3,11 @@ module.exports = {
   description: 'Lists the currently uploaded deploy-revisions',
   works: 'insideProject',
 
+  anonymousOptions: [
+    '<deployTarget>'
+  ],
+
   availableOptions: [
-    { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
     { name: 'deploy-config-file', type: String, default: 'config/deploy.js' }
   ],
 

--- a/lib/tasks/pipeline.js
+++ b/lib/tasks/pipeline.js
@@ -24,10 +24,10 @@ module.exports = Task.extend({
 
     var root = this.project.root;
 
-    this.deployEnvironment = this.deployEnvironment || 'production';
-    this.commandLineArgs = this.commandLineArgs || {};
+    this.deployTarget = this.deployTarget || 'production';
+    this.commandOptions = this.commandOptions || {};
 
-    var dotEnvFilename = '.env.deploy.' + this.deployEnvironment;
+    var dotEnvFilename = '.env.deploy.' + this.deployTarget;
     var dotEnvFilePath = path.join(root, dotEnvFilename);
 
     if (existsSync(dotEnvFilePath)) {
@@ -54,17 +54,17 @@ module.exports = Task.extend({
   },
 
   run: function(hooks) {
-    var self            = this;
-    var pipeline        = this._pipeline;
-    var ui              = this.ui;
-    var project         = this.project;
-    var commandLineArgs = this.commandLineArgs;
+    var self           = this;
+    var pipeline       = this._pipeline;
+    var ui             = this.ui;
+    var project        = this.project;
+    var commandOptions = this.commandOptions;
 
     return this.setup().then(function(deployConfig){
       var context = {
-        commandLineArgs: commandLineArgs,
+        commandOptions: commandOptions,
         config: deployConfig,
-        deployEnvironment: self.deployEnvironment,
+        deployTarget: self.deployTarget,
         project: project,
         ui: ui
       };
@@ -75,7 +75,7 @@ module.exports = Task.extend({
   _readDeployConfig: function() {
     var project         = this.project;
     var deployConfigFn  = require(path.join(project.root, this.deployConfigPath));
-    return Promise.resolve(deployConfigFn(this.deployEnvironment));
+    return Promise.resolve(deployConfigFn(this.deployTarget));
   },
 
   _registerPipelineHooks: function(addon, deployConfig) {

--- a/node-tests/unit/tasks/pipeline-test.js
+++ b/node-tests/unit/tasks/pipeline-test.js
@@ -41,7 +41,7 @@ describe('PipelineTask', function() {
         var task = new PipelineTask({
           project: project,
           ui: mockUi,
-          deployEnvironment: 'development',
+          deployTarget: 'development',
           deployConfigPath: 'node-tests/fixtures/config/deploy.js',
           hooks: ['willDeploy', 'upload']
         });
@@ -77,7 +77,7 @@ describe('PipelineTask', function() {
         var task = new PipelineTask({
           project: project,
           ui: mockUi,
-          deployEnvironment: 'development',
+          deployTarget: 'development',
           deployConfigPath: 'node-tests/fixtures/config/deploy.js',
           hooks: ['willDeploy', 'upload']
         });
@@ -116,7 +116,7 @@ describe('PipelineTask', function() {
         var task = new PipelineTask({
           project: project,
           ui: mockUi,
-          deployEnvironment: 'development',
+          deployTarget: 'development',
           deployConfigPath: 'node-tests/fixtures/config/deploy.js',
           hooks: ['willDeploy', 'upload']
         });
@@ -148,7 +148,7 @@ describe('PipelineTask', function() {
         var task = new PipelineTask({
           project: project,
           ui: mockUi,
-          deployEnvironment: 'development',
+          deployTarget: 'development',
           deployConfigPath: 'node-tests/fixtures/config/deploy.js',
           hooks: ['willDeploy', 'upload']
         });
@@ -199,7 +199,7 @@ describe('PipelineTask', function() {
         var task = new PipelineTask({
           project: project,
           ui: mockUi,
-          deployEnvironment: 'development',
+          deployTarget: 'development',
           deployConfigPath: 'node-tests/fixtures/config/deploy-for-addons-config-test.js',
           hooks: ['willDeploy', 'upload']
         });
@@ -250,7 +250,7 @@ describe('PipelineTask', function() {
         var task = new PipelineTask({
           project: project,
           ui: mockUi,
-          deployEnvironment: 'development',
+          deployTarget: 'development',
           deployConfigPath: 'node-tests/fixtures/config/deploy.js',
           hooks: ['willDeploy', 'upload']
         });
@@ -282,9 +282,9 @@ describe('PipelineTask', function() {
       var task = new PipelineTask({
         project: project,
         ui: mockUi,
-        deployEnvironment: 'development',
+        deployTarget: 'development',
         deployConfigPath: 'node-tests/fixtures/config/deploy.js',
-        commandLineArgs: {revision: '123abc'},
+        commandOptions: {revision: '123abc'},
         hooks: ['willDeploy', 'upload'],
         pipeline: {
           execute: function(context) {
@@ -300,9 +300,9 @@ describe('PipelineTask', function() {
           expect(pipelineExecuted).to.be.true;
           expect(pipelineContext.ui).to.eq(mockUi);
           expect(pipelineContext.project).to.eq(project);
-          expect(pipelineContext.deployEnvironment).to.eq('development');
+          expect(pipelineContext.deployTarget).to.eq('development');
           expect(pipelineContext.config.build.buildEnv).to.eq('development');
-          expect(pipelineContext.commandLineArgs.revision).to.eq('123abc');
+          expect(pipelineContext.commandOptions.revision).to.eq('123abc');
         });
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-deploy",
   "description": "An Ember-CLI Addon for `Lightning Fast Deployments of Ember-CLI Apps`",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
* Move to `ember deploy <deploy-target> [--activate]` and `ember deploy:activate <deploy-target> --revision=abc123etc`
* Move from DEPLOY_ENVIRONMENT env var to DEPLOY_TARGET env var
* provide `commandOptions` on context instead of `commandLineArgs`

The motivation for this change was to avoid confusion about the term `environment` and be more succinct.