### PR TITLE
Update deprecated build configuration filename

### DIFF
--- a/docs/v0.4.x/fingerprinting-options-and-staging-environments.md
+++ b/docs/v0.4.x/fingerprinting-options-and-staging-environments.md
@@ -8,7 +8,7 @@ most production scenarios you will need to provide a `prepend`-property to your
 app's fingerprint-property (to reference your CDN served assets correctly).
 
 ```javascript
-// Brocfile.js
+// ember-cli-build.js
 var app = new EmberApp({
   fingerprint: {
     prepend: 'https://subdomain.cloudfront.net/'
@@ -22,7 +22,7 @@ var app = new EmberApp({
 environments manually. You can do someting like this:
 
 ```javascript
-// Brocfile.js
+// ember-cli-build.js
 var env = EmberApp.env();
 var isProductionLikeBuild = ['production', 'staging'].indexOf(env) > -1;
 


### PR DESCRIPTION
The build configuration filename was changed from Brocfile.js to ember-cli-build.js in ember-cli 1.13.0

See https://github.com/ember-cli/ember-cli/blob/275cc36807698968050f80ef8c64e8bd6726ba72/CHANGELOG.md#1130