### PR TITLE
Implement aliases to support multiple instances of plugins

### DIFF
--- a/lib/tasks/pipeline.js
+++ b/lib/tasks/pipeline.js
@@ -46,34 +46,47 @@ module.exports = Task.extend({
   setup: function(){
     var self = this;
     return this._readDeployConfig().then(function(deployConfig){
-      self._plugins = Object.create(null);
-      (self.project.addons || []).forEach(function(addon){
-        self._registerPlugin(addon);
-      });
+      self._installedPlugins = self._discoverInstalledPlugins();
 
-      var aliasHash = self._aliasHash(deployConfig, self._plugins);
+      var plugins;
+      var configuredPluginList = deployConfig.plugins;
+      if (configuredPluginList) {
+        plugins = self._configuredPlugins(configuredPluginList, self._installedPlugins);
+      } else {
+        // no whitelist available, use all autodiscovered plugins
+        plugins = self._installedPlugins;
+      }
 
-      Object.keys(aliasHash).forEach(function(alias) {
-        self._registerPipelineHooks(aliasHash[alias], alias);
+      Object.keys(plugins).forEach(function(pluginName) {
+        self._registerPipelineHooks(plugins[pluginName], pluginName);
       });
 
       return deployConfig;
     });
   },
 
-  _registerPlugin: function(addon) {
+  _discoverInstalledPlugins: function(){
+    var self = this;
+    var installedPlugins = Object.create(null);
+    (this.project.addons || []).forEach(function(addon){
+      self._registerInstalledPlugin(addon, installedPlugins);
+    });
+    return installedPlugins;
+  },
+
+  _registerInstalledPlugin: function(addon, registry) {
     var self = this;
 
     if (this._isDeployPluginPack(addon)) {
       addon.addons.forEach(function(nestedAddon){
-        self._registerPlugin(nestedAddon);
+        self._registerInstalledPlugin(nestedAddon, registry);
       });
       return;
     }
 
     if (!this._isValidDeployPlugin(addon)) { return; }
 
-    this._plugins[this._pluginName(addon)] = addon;
+    registry[this._pluginNameFromAddonName(addon)] = addon;
   },
 
   run: function(hooks) {
@@ -101,40 +114,33 @@ module.exports = Task.extend({
     return Promise.resolve(deployConfigFn(this.deployTarget));
   },
 
-  _aliasHash: function(deployConfig, plugins) {
-    var aliasList = deployConfig.plugins;
-    if(!aliasList) {
-      // no whitelist available, autodiscover all the plugins
-      aliasList = Object.keys(plugins);
-    }
-
-
+  _configuredPlugins: function(configuredPluginNames, availablePlugins) {
     var unavailablePlugins = Object.create(null);
-    var aliasHash = Object.create(null);
+    var configuredPlugins = Object.create(null);
 
-    aliasList.forEach(function(alias) {
-      var split = alias.split(':', 2);
-      var pluginName = split[0];
-      var configuredName = split[1] ? split[1] : split[0];
+    configuredPluginNames.forEach(function(configuredPluginKey) {
+      var parts = configuredPluginKey.split(':', 2);
+      var pluginName = parts[0];
+      var configuredName = parts[1] ? parts[1] : parts[0];
 
-      aliasHash[configuredName] = plugins[pluginName];
-
-      if(!aliasHash[configuredName]) {
+      if (availablePlugins[pluginName]) {
+        configuredPlugins[configuredName] = availablePlugins[pluginName];
+      } else {
         unavailablePlugins[configuredName] = pluginName;
       }
     });
 
-    if(Object.keys(unavailablePlugins).length !== 0) {
-      console.log(unavailablePlugins);
-      var error = new SilentError('Configured alias for plugins, which are not available.');
+    if (Object.keys(unavailablePlugins).length !== 0) {
+      this.ui.writeError(unavailablePlugins);
+      var error = new SilentError('plugins configuration references plugins which are not available.');
       error.unavailablePlugins = unavailablePlugins;
       throw error;
     }
 
-    return aliasHash;
+    return configuredPlugins;
   },
 
-  _pluginName: function(addon) {
+  _pluginNameFromAddonName: function(addon) {
     var pluginNameRegex = /^(ember\-cli\-deploy\-)(.*)$/;
     return addon.name.match(pluginNameRegex)[2];
   },

--- a/lib/tasks/pipeline.js
+++ b/lib/tasks/pipeline.js
@@ -46,11 +46,34 @@ module.exports = Task.extend({
   setup: function(){
     var self = this;
     return this._readDeployConfig().then(function(deployConfig){
-      self.project.addons.forEach(function(addon){
-        self._registerPipelineHooks(addon, deployConfig);
+      self._plugins = Object.create(null);
+      (self.project.addons || []).forEach(function(addon){
+        self._registerPlugin(addon);
       });
+
+      var aliasHash = self._aliasHash(deployConfig, self._plugins);
+
+      Object.keys(aliasHash).forEach(function(alias) {
+        self._registerPipelineHooks(aliasHash[alias], alias);
+      });
+
       return deployConfig;
     });
+  },
+
+  _registerPlugin: function(addon) {
+    var self = this;
+
+    if (this._isDeployPluginPack(addon)) {
+      addon.addons.forEach(function(nestedAddon){
+        self._registerPlugin(nestedAddon);
+      });
+      return;
+    }
+
+    if (!this._isValidDeployPlugin(addon)) { return; }
+
+    this._plugins[this._pluginName(addon)] = addon;
   },
 
   run: function(hooks) {
@@ -78,26 +101,47 @@ module.exports = Task.extend({
     return Promise.resolve(deployConfigFn(this.deployTarget));
   },
 
-  _registerPipelineHooks: function(addon, deployConfig) {
-    var self = this;
-    var configuredPluginList = deployConfig.plugins;
-
-    if (this._isDeployPluginPack(addon)) {
-      addon.addons.forEach(function(nestedAddon){
-        self._registerPipelineHooks(nestedAddon, deployConfig);
-      });
-      return;
+  _aliasHash: function(deployConfig, plugins) {
+    var aliasList = deployConfig.plugins;
+    if(!aliasList) {
+      // no whitelist available, autodiscover all the plugins
+      aliasList = Object.keys(plugins);
     }
 
-    if (!this._isValidDeployPlugin(addon)) { return; }
 
+    var unavailablePlugins = Object.create(null);
+    var aliasHash = Object.create(null);
+
+    aliasList.forEach(function(alias) {
+      var split = alias.split(':', 2);
+      var pluginName = split[0];
+      var configuredName = split[1] ? split[1] : split[0];
+
+      aliasHash[configuredName] = plugins[pluginName];
+
+      if(!aliasHash[configuredName]) {
+        unavailablePlugins[configuredName] = pluginName;
+      }
+    });
+
+    if(Object.keys(unavailablePlugins).length !== 0) {
+      console.log(unavailablePlugins);
+      var error = new SilentError('Configured alias for plugins, which are not available.');
+      error.unavailablePlugins = unavailablePlugins;
+      throw error;
+    }
+
+    return aliasHash;
+  },
+
+  _pluginName: function(addon) {
     var pluginNameRegex = /^(ember\-cli\-deploy\-)(.*)$/;
-    var name            = addon.name.match(pluginNameRegex)[2];
-    if (configuredPluginList && configuredPluginList.indexOf(name) === -1) {
-      return;
-    }
+    return addon.name.match(pluginNameRegex)[2];
+  },
 
-    var deployPlugin = addon.createDeployPlugin({name: name});
+  _registerPipelineHooks: function(addon, alias) {
+    var self = this;
+    var deployPlugin = addon.createDeployPlugin({name: alias});
 
     this._pipeline.hookNames().forEach(function(hookName) {
       var fn = deployPlugin[hookName];

--- a/node-tests/fixtures/config/deploy-for-addons-config-test-with-alias.js
+++ b/node-tests/fixtures/config/deploy-for-addons-config-test-with-alias.js
@@ -1,0 +1,5 @@
+module.exports = function(environment) {
+  return {
+    plugins: ['foo-plugin:bar-alias']
+  };
+}

--- a/node-tests/fixtures/config/deploy-for-addons-config-test-with-aliases.js
+++ b/node-tests/fixtures/config/deploy-for-addons-config-test-with-aliases.js
@@ -1,0 +1,5 @@
+module.exports = function(environment) {
+  return {
+    plugins: ['foo-plugin', 'foo-plugin:bar-alias', 'foo-plugin:doo-alias']
+  };
+}

--- a/node-tests/unit/tasks/pipeline-test.js
+++ b/node-tests/unit/tasks/pipeline-test.js
@@ -6,7 +6,7 @@ var assert       = require('chai').assert;
 describe('PipelineTask', function() {
   var mockProject   = {addons: []};
   var mockConfig    = {};
-  var mockUi        = { write: function() {} };
+  var mockUi        = { write: function() {},  writeError: function() {} };
 
   describe('creating and setting up a new instance', function() {
     it ('raises an error if project is not provided', function() {
@@ -29,6 +29,9 @@ describe('PipelineTask', function() {
     });
 
     describe('setting environment variables from .env', function() {
+      beforeEach(function(){
+        delete process.env.ENVTEST;
+      });
       it('sets the process.env vars if a .env file exists for deploy environment', function() {
         var project = {
           name: function() {return 'test-project';},


### PR DESCRIPTION
Hey,

this is my initial attempt of implementing the alias feature for plugins.

I tested with the redis-plugin, which does not correctly use the passed in name yet.
See https://github.com/zapnito/ember-cli-deploy-redis/pull/18 .


BR,
Domme

