### PR TITLE
Fix broken/wrong pipeline tests

### DIFF
--- a/node-tests/fixtures/config/deploy-for-addons-config-test.js
+++ b/node-tests/fixtures/config/deploy-for-addons-config-test.js
@@ -1,5 +1,5 @@
 module.exports = function(environment) {
   return {
-    plugins: ['foo-plugin']
+    plugins: ['foo-plugin', 'test-plugin']
   };
 }

--- a/node-tests/unit/tasks/pipeline-test.js
+++ b/node-tests/unit/tasks/pipeline-test.js
@@ -78,7 +78,7 @@ describe('PipelineTask', function() {
           project: project,
           ui: mockUi,
           deployTarget: 'development',
-          deployConfigPath: 'node-tests/fixtures/config/deploy.js',
+          deployConfigPath: 'node-tests/fixtures/config/deploy-for-addons-config-test.js',
           hooks: ['willDeploy', 'upload']
         });
         return task.setup().then(function(){
@@ -251,7 +251,7 @@ describe('PipelineTask', function() {
           project: project,
           ui: mockUi,
           deployTarget: 'development',
-          deployConfigPath: 'node-tests/fixtures/config/deploy.js',
+          deployConfigPath: 'node-tests/fixtures/config/deploy-for-addons-config-test.js',
           hooks: ['willDeploy', 'upload']
         });
         return task.setup().then(function(){


### PR DESCRIPTION
While implementing plugin aliases, I ran into two failing tests, which I believe are broken.

`deploy.js` does not whitelist any plugins, thus they can't be registered. And the whitelist can't be added to `deploy.js` because it's also used to test what happens if there's no whitelist at all. Thus I changed the tests to use a different fixture.

What's spurious tho:
Why didn't the test fail that ensures that plugins are only added if they are whitelisted?

https://github.com/ember-cli/ember-cli-deploy/blob/0.5.0-dev/node-tests/unit/tasks/pipeline-test.js#L161