### PR TITLE
Fix bug where fingerprint options in deploy.js don't work

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ Deploy.prototype.blueprintsPath = function() {
 };
 
 Deploy.prototype.included = function(app) {
-  var deployEnv  = this._deployEnvSetByDeployCommand();
+  var deployEnv  = this._deployTargetSetByDeployCommand();
   var root       = app.project.root;
   var configPath = path.join(root, 'config', 'deploy');
   var config;
@@ -58,8 +58,8 @@ Deploy.prototype.included = function(app) {
   }
 };
 
-Deploy.prototype._deployEnvSetByDeployCommand = function() {
-  return process.env.DEPLOY_ENVIRONMENT;
+Deploy.prototype._deployTargetSetByDeployCommand = function() {
+  return process.env.DEPLOY_TARGET;
 }
 
 module.exports = Deploy;


### PR DESCRIPTION
Previous to [this commit](https://github.com/ember-cli/ember-cli-deploy/commit/42e3c13f863af3108351411bf93d3d45f2c4b258) a user could specify fingerprinting options in `deploy.js` instead of in their `Brocfile.js`.

Due to the renaming of `DEPLOY_ENVIRONMENT` to `DEPLOY_TARGET` in the above commit, this functionality broke.  This PR fixes that.

So, now users can specify fingerprinting options in `deploy.js` like so:

```javascript
module.exports = function(environment) {
  return {
    fingerprint: {
      enabled: environment === 'production',
      prepend: 'https://some-url.com/'
    }
  };
}
```