### PR TITLE
Fix typo: Lightening -> Lightning

### DIFF
--- a/_data/navs.yml
+++ b/_data/navs.yml
@@ -4,7 +4,7 @@ v0.4.x:
     path: ''
   - label: Installation
   - label: Commands
-  - label: Lightening approach workflow
+  - label: Lightning approach workflow
   - label: Configuration
   - label: How to use
   - label: Fingerprinting options and staging environments


### PR DESCRIPTION
This fixes a broken link in the docs nav.