### PR TITLE
Remove deploy:index and deploy:assets from DOCs

### DIFF
--- a/docs/v0.4.x/commands.md
+++ b/docs/v0.4.x/commands.md
@@ -4,8 +4,6 @@ title: Commands
 
 This Ember-CLI Addon adds multiple deployment related tasks to your Ember-CLI App.
 
-* `ember deploy:assets` Uploads your production assets to a static file hoster.
-* `ember deploy:index` Uploads a bootstrap index.html to a key-value store.
 * `ember deploy:list` Lists all currently uploaded `revisions` of bootstrap index.html files in your key-value store.
 * `ember deploy:activate` Activates an uploaded `revision`. This will set the `<your-project-name>:current` revision to the passed revision. `<your-project-name>:current` is the revision you will serve your users as default.
 * `ember deploy` This commands builds your ember application, uploads it to your file hoster and uploads it to your key value store in one step.


### PR DESCRIPTION
I tried to do a `deploy:index` and was told that it was deprecated and I reckon this holds for `deploy:assets`, too.