### PR TITLE
Remove modifying fingerprint options on `included` hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,31 +14,4 @@ Deploy.prototype.blueprintsPath = function() {
   return path.join(__dirname, 'blueprints');
 };
 
-Deploy.prototype.included = function(app) {
-  var deployEnv  = this._deployTargetSetByDeployCommand();
-  var root       = app.project.root;
-  var configPath = path.join(root, 'config', 'deploy');
-  var config;
-  var fingerprint;
-
-  if (deployEnv) {
-    config = require(configPath)(deployEnv);
-
-    if (config.fingerprint === false) {
-      app.options.fingerprint = {enabled: false};
-    } else {
-      fingerprint = config.fingerprint || {};
-      app.options.fingerprint = app.options.fingerprint || {};
-
-      for (var option in fingerprint) {
-        app.options.fingerprint[option] = fingerprint[option];
-      }
-    }
-  }
-};
-
-Deploy.prototype._deployTargetSetByDeployCommand = function() {
-  return process.env.DEPLOY_TARGET;
-}
-
 module.exports = Deploy;

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
   ],
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "defaultBlueprint": "deploy-config",
-    "before": "broccoli-asset-rev"
+    "defaultBlueprint": "deploy-config"
   },
   "dependencies": {
     "broccoli": "^0.13.2",


### PR DESCRIPTION
It was decided that until we can pluginerize asset-rev, we should
continue to set broccoli-asset-rev options in the Brocfile.js