### PR TITLE
Add: activate pipeline runs `fetchRevisions`-hook

### DIFF
--- a/lib/commands/activate.js
+++ b/lib/commands/activate.js
@@ -25,6 +25,7 @@ module.exports = {
       commandOptions: commandOptions,
       hooks: [
         'configure',
+        'fetchRevisions',
         'willActivate',
         'activate',
         'didActivate'

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -46,6 +46,7 @@ module.exports = {
       'willBuild', 'build', 'didBuild',
       'willPrepare', 'prepare', 'didPrepare',
       'willUpload', 'upload', 'didUpload',
+      'fetchRevisions',
       'willActivate', 'activate', 'didActivate',
       'didDeploy'
     ];


### PR DESCRIPTION
It makes sense for the activate pipeline command to run the
`fetchRevisions`-hook because activation will depend on the
available revisions in most cases.