### PR TITLE
add setup and teardown hooks to all commands

### DIFF
--- a/lib/commands/activate.js
+++ b/lib/commands/activate.js
@@ -25,9 +25,11 @@ module.exports = {
       commandOptions: commandOptions,
       hooks: [
         'configure',
+        'setup',
         'willActivate',
         'activate',
-        'didActivate'
+        'didActivate',
+        'teardown'
       ]
     });
 

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -42,12 +42,14 @@ module.exports = {
 
   _hooks: function(shouldActivate) {
     var hooks = ['configure',
+      'setup',
       'willDeploy',
       'willBuild', 'build', 'didBuild',
       'willPrepare', 'prepare', 'didPrepare',
       'willUpload', 'upload', 'didUpload',
       'willActivate', 'activate', 'didActivate',
-      'didDeploy'
+      'didDeploy',
+      'teardown'
     ];
 
     if (!shouldActivate) {

--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -25,8 +25,10 @@ module.exports = {
       commandOptions: commandOptions,
       hooks: [
         'configure',
+        'setup',
         'fetchRevisions',
-        'displayRevisions'
+        'displayRevisions',
+        'teardown'
       ]
     });
 

--- a/rfc/plugins.md
+++ b/rfc/plugins.md
@@ -130,6 +130,10 @@ module.exports = return function(environment) {
 These hooks (part of a typical deployment process) are available for plugins to implement:
 
 ```
+configure: ---> runs before anything happens
+
+setup: -------> the first hook for every command
+
 willDeploy: --> runs before anything happens. good opportunity for plugins to validate
                 configuration or other preconditions
 
@@ -166,6 +170,8 @@ activate -------> make a new version live (clear cache, swap Redis values, etc.)
         the ID of the version to be activated.
 
 didDeploy: --> runs at the end of a full deployment operation.
+
+teardown: ---> always the last hook being run
 ```
 
 In addition, there are a few more specialized hooks that plugins may implement:


### PR DESCRIPTION
after discussion with @lukemelia we're proposing to add two extra hooks that should be implemented in every command (like the configure hook)

`setup`
`teardown`

these are useful for things that have to be setup "around" every command like port-forwarding.

@achambers this seems to be inline with what we discussed as well but let me know your feedback!
