### PR TITLE
Add support for ember-cli-dotenv

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "ember-addon",
     "ember-cli-deploy"
   ],
+  "ember-addon": {
+    "after": "ember-cli-dotenv"
+  },
   "dependencies": {
     "broccoli": "^0.13.2",
     "broccoli-gzip": "^0.2.0",


### PR DESCRIPTION
Hi!

I'm working through setting up Ember CLI Deploy and noticed #77 talking about using ENV variables through Ember CLI dotenv.

This ensures that `process.env` has the environment variables loaded by Ember CLI dotenv when loading `config/deploy.js` and has no side effects if `ember-cli-dotenv` is not present. :smiley_cat:

I debated whether or not I should open this PR on ember-cli-dotenv, but this allows an easy path for storing and accessing sensitive credentials at deploy time.