### PR TITLE
Add support for postBuildDeployHook

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,75 @@ After installation, choose [deployment adapters](http://ember-cli.github.io/embe
 
 [Visit the Docs site](http://ember-cli.github.io/ember-cli-deploy/)
 
+## Development workflow
+
+Why do this? `ember-cli-deploy` is an addon for deploying apps. It works fine for cases where your ember-cli app and API app are mostly developed in isolation. However, if you develop your apps more closely or rely on your API app to inject session or initial state data into your ember-cli app's index page, the development process can be cumbersome.
+
+This workflow simply writes your ember-cli app's index to your index plugin on each build so that your API app can read (and possibly modify it) just like it would in production.
+
+During app development use `ember server` just to recompile and serve the assets as usual.
+This way the ember app is served by your backend and there's no need to setup CORS or proxies.
+
+This strategy can be easily accomplished with some configurations parameters.
+
+The following is an example that pushes the `index.html` to redis on each build:
+
+in your `ember-cli-build.js`
+
+```javascript
+  module.exports = function(defaults) {
+    var env = EmberApp.env()|| 'development';
+    ...
+
+    var fingerprintOptions = {
+      enabled: true,
+      ...
+    };
+
+    switch (env) {
+      case 'development':
+        fingerprintOptions.prepend = 'http://localhost:4200/'; // use fingerprinting to prepend your ember server domain path
+      break;
+      ...
+    }
+
+    var app = new EmberApp(defaults, {
+      fingerprint: fingerprintOptions,
+      emberCLIDeploy: {
+        runOnPostBuild: (env === 'development') ? 'development-postbuild' : false, // returns the deployTarget
+        configFile: 'config/deploy.js', // optionally specifiy a different config file
+        shouldActivate: true, // optionally call the activate hook on deploy
+      },
+      ...
+    });
+
+    return app.toTree();
+  };
+```
+
+in `config/deploy.js` you can define a custom pipeline for your deploy env.
+
+```javascript
+  if (deployTarget === 'development-postbuild') {
+    ENV.plugins = ['redis']; // only use the redis pluging
+    ENV.build = {
+      environment: 'development'
+    };
+
+    ENV.redis = {
+      keyPrefix: 'edd-cli',
+      revisionKey: '__development__',
+      allowOverwrite: true,
+      type: 'redis', // this can be omitted because it is the default
+      host: 'localhost',
+      port: 6379,
+      distDir: function(context) {
+        return context.commandOptions.buildDir;
+      }
+    };
+  }
+```
+
 ## Contributing
 
 Clone the repo and run `npm install`. To run tests,

--- a/README.md
+++ b/README.md
@@ -18,14 +18,16 @@ After installation, choose [deployment adapters](http://ember-cli.github.io/embe
 
 ## Development workflow
 
-Why do this? `ember-cli-deploy` is an addon for deploying apps. It works fine for cases where your ember-cli app and API app are mostly developed in isolation. However, if you develop your apps more closely or rely on your API app to inject session or initial state data into your ember-cli app's index page, the development process can be cumbersome.
+`ember-cli-deploy` is an addon for deploying apps. It works fine for cases where your ember-cli app and API app are mostly developed in isolation. However, there are some cases where using the `--proxy` command line option is inadequate. For example:
+ * authentication happens within your API application
+ * you are progressively updating an app to Ember or developing a hybrid app (i.e. some pages are served by the API application) and you need both applications to work together seamlessly
+ * the API app injects some initial state (e.g. session info or model preloads) into your ember-cli app's index page so that it is available without having to make xhr requests on boot
 
-This workflow simply writes your ember-cli app's index to your index plugin on each build so that your API app can read (and possibly modify it) just like it would in production.
+The development workflow simply writes your ember-cli app's index to your key-value store on each build so that your API app can read (and possibly modify) it just as it would in production.
 
-During app development use `ember server` just to recompile and serve the assets as usual.
-This way the ember app is served by your backend and there's no need to setup CORS or proxies.
+During app development `ember server` is used to recompile and serve the assets as usual while the app index is served by your API app, eliminating the need to setup CORS or proxies.
 
-This strategy can be easily accomplished with some configurations parameters.
+This strategy can be easily accomplished with some `ember-cli-build.js` configuration. Keep in mind that you will need to modify your `fingerprintOptions` in development to prepend your ember-cli server host and port. This way requests for Ember assets still go to ember-cli and not your API application.
 
 The following is an example that pushes the `index.html` to redis on each build:
 

--- a/index.js
+++ b/index.js
@@ -1,17 +1,35 @@
 var path                = require('path');
 var commands            = require('./lib/commands');
 
-function Deploy() {
-  this.name = 'ember-cli-deploy';
-  return this;
-}
+module.exports = {
+  name: 'ember-cli-deploy',
 
-Deploy.prototype.includedCommands = function() {
-  return commands;
+  includedCommands: function() {
+    return commands;
+  },
+
+  blueprintsPath: function() {
+    return path.join(__dirname, 'blueprints');
+  },
+
+  postBuild: function(result) {
+    var options = this.app.options.emberCLIDeploy || {};
+
+    var deployTarget = options.runOnPostBuild;
+    if (deployTarget) {
+      var DeployTask = require('./lib/tasks/deploy');
+      var deploy = new DeployTask({
+        project: this.project,
+        ui: this.ui,
+        deployTarget: deployTarget,
+        deployConfigFile: options.configFile,
+        shouldActivate: options.shouldActivate,
+        commandOptions: {
+          buildDir: result.directory
+        }
+      });
+
+      return deploy.run();
+    }
+  }
 };
-
-Deploy.prototype.blueprintsPath = function() {
-  return path.join(__dirname, 'blueprints');
-};
-
-module.exports = Deploy;

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -1,6 +1,3 @@
-var existsSync  = require('fs').existsSync;
-var path        = require('path');
-
 module.exports = {
   name: 'deploy',
   description: 'Deploys an ember-cli app',
@@ -19,58 +16,17 @@ module.exports = {
     commandOptions.deployTarget = rawArgs.shift();
     process.env.DEPLOY_TARGET = commandOptions.deployTarget;
 
-    var shouldActivate = this._shouldActivate(commandOptions);
-
-    var PipelineTask = require('../tasks/pipeline');
-    var pipeline = new PipelineTask({
+    var DeployTask = require('../tasks/deploy');
+    var deploy = new DeployTask({
       project: this.project,
       ui: this.ui,
       deployTarget: commandOptions.deployTarget,
-      deployConfigPath: commandOptions.deployConfigFile,
-      commandOptions: commandOptions,
-      hooks: this._hooks(shouldActivate)
+      deployConfigFile: commandOptions.deployConfigFile,
+      commandOptions: this.commandOptions
     });
 
-    return pipeline.run();
+    return deploy.run();
+
   },
 
-  _shouldActivate: function(options) {
-    var config = this._pipelineConfig(options);
-    var referToPipelineConfig = (options.activate === undefined);
-    return referToPipelineConfig ? config.activateOnDeploy : options.activate;
-  },
-
-  _hooks: function(shouldActivate) {
-    var hooks = ['configure',
-      'setup',
-      'willDeploy',
-      'willBuild', 'build', 'didBuild',
-      'willPrepare', 'prepare', 'didPrepare',
-      'willUpload', 'upload', 'didUpload',
-      'willActivate', 'activate', 'didActivate',
-      'didDeploy',
-      'teardown'
-    ];
-
-    if (!shouldActivate) {
-      hooks.splice(hooks.indexOf('willActivate'), 3);
-    }
-
-    return hooks;
-  },
-
-  _pipelineConfig: function(options) {
-    var root = this.project.root;
-    var filePath = options.deployConfigFile;
-    var fullPath = path.join(root, filePath);
-    var deployTarget = options.deployTarget;
-
-    if (!existsSync(fullPath)) {
-      return {};
-    }
-
-    var fn = require(fullPath);
-
-    return fn(deployTarget)['pipeline'] || {};
-  }
 };

--- a/lib/tasks/deploy.js
+++ b/lib/tasks/deploy.js
@@ -1,0 +1,64 @@
+var Task        = require('ember-cli/lib/models/task');
+var existsSync  = require('fs').existsSync;
+var path        = require('path');
+var PipelineTask = require('../tasks/pipeline');
+
+module.exports = Task.extend({
+  init: function() {
+    this.commandOptions = this.commandOptions || {};
+    this.shouldActivate = this.shouldActivate || this._shouldActivate(this.commandOptions);
+  },
+
+  run: function() {
+    var pipeline = this._pipeline || new PipelineTask({
+      project: this.project,
+      ui: this.ui,
+      deployTarget: this.deployTarget,
+      deployConfigPath: this.deployConfigFile,
+      commandOptions: this.commandOptions,
+      hooks: this._hooks(this.shouldActivate)
+    });
+    return pipeline.run();
+  },
+
+  _shouldActivate: function(options) {
+    var config = this._pipelineConfig();
+    var referToPipelineConfig = (options.activate === undefined);
+    return referToPipelineConfig ? config.activateOnDeploy : options.activate;
+  },
+
+  _hooks: function(shouldActivate) {
+    var hooks = ['configure',
+      'setup',
+      'willDeploy',
+      'willBuild', 'build', 'didBuild',
+      'willPrepare', 'prepare', 'didPrepare',
+      'willUpload', 'upload', 'didUpload',
+      'willActivate', 'activate', 'didActivate',
+      'didDeploy',
+      'teardown'
+    ];
+
+    if (!shouldActivate) {
+      hooks.splice(hooks.indexOf('willActivate'), 3);
+    }
+
+    return hooks;
+  },
+
+  _pipelineConfig: function() {
+    var root = this.project.root;
+    var filePath = this.deployConfigFile;
+    var fullPath = path.join(root, filePath);
+    var deployTarget = this.deployTarget;
+
+    if (!existsSync(fullPath)) {
+      return {};
+    }
+
+    var fn = require(fullPath);
+
+    return fn(deployTarget)['pipeline'] || {};
+  }
+
+});

--- a/node-tests/fixtures/config/deploy-postbuild.js
+++ b/node-tests/fixtures/config/deploy-postbuild.js
@@ -1,0 +1,11 @@
+module.exports = function(environment) {
+  var ENV = {};
+
+  if (environment === 'development-postbuild') {
+    ENV.pipeline = {
+      activateOnDeploy: true
+    };
+  }
+
+  return ENV;
+};

--- a/node-tests/unit/tasks/deploy-test.js
+++ b/node-tests/unit/tasks/deploy-test.js
@@ -1,0 +1,91 @@
+var Promise      = require('ember-cli/lib/ext/promise');
+var DeployTask = require('../../../lib/tasks/deploy');
+var expect       = require('../../helpers/expect');
+var assert       = require('chai').assert;
+
+describe('DeployTask', function() {
+  var mockProject   = {addons: []};
+  var mockConfig    = {};
+  var mockUi        = { write: function() {},  writeError: function() {} };
+
+  describe('creating and setting up a new instance', function() {
+
+    describe('detects that shouldActivate', function() {
+      it('is passed as a value', function() {
+        var deploy = new DeployTask({
+          project: mockProject,
+          ui: mockUi,
+          deployTarget: 'development-postbuild',
+          deployConfigFile: 'node-tests/fixtures/config/deploy-postbuild.js',
+          shouldActivate: true
+        });
+        expect(deploy.shouldActivate).to.eq(true);
+      });
+
+      it('is specified in the deploy config', function() {
+        var project = {
+          name: function() {return 'test-project';},
+          root: process.cwd(),
+          addons: []
+        };
+        var deploy = new DeployTask({
+          project: project,
+          ui: mockUi,
+          deployTarget: 'development-postbuild',
+          deployConfigFile: 'node-tests/fixtures/config/deploy-postbuild.js',
+        });
+        expect(deploy.shouldActivate).to.eq(true);
+      });
+
+      it('is passed as a commandLine option', function() {
+        var project = {
+          name: function() {return 'test-project';},
+          root: process.cwd(),
+          addons: []
+        };
+        var deploy = new DeployTask({
+          project: project,
+          ui: mockUi,
+          deployTarget: 'development-postbuild',
+          deployConfigFile: 'node-tests/fixtures/config/deploy.js',
+          commandOptions: {
+            activate: true
+          }
+        });
+        expect(deploy.shouldActivate).to.eq(true);
+      });
+  });
+
+  describe('executing the deployTask', function() {
+    it ('executes the pipelineTask', function() {
+      var pipelineExecuted = false;
+      var pipelineContext;
+
+      var project = {
+        name: function() {return 'test-project';},
+        root: process.cwd(),
+        addons: [ ]
+      };
+
+      var task = new DeployTask({
+        project: project,
+        ui: mockUi,
+        deployTarget: 'development',
+        deployConfigFile: 'node-tests/fixtures/config/deploy.js',
+        _pipeline: {
+          run: function() {
+            pipelineExecuted = true;
+            return Promise.resolve();
+          }
+        }
+      });
+
+      return expect(task.run()).to.be.fulfilled
+        .then(function() {
+          expect(pipelineExecuted).to.eq(true);
+        });
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
this adds a config option that will trigger a specific pipeline
every time the project is built.

the use case is to enable pushing assets to a store during development

for example: users of the redis plugin could use this config to get
an updated `index.html` in their redis store:

```
    if (deployTarget === 'development-postbuild') {
      ENV.plugins = ['redis'];
      ENV.build = {
        environment: 'development'
      };

      ENV.redis = {
        keyPrefix: 'edd-cli',
        revisionKey: '__development__',
        allowOverwrite: true,
        type: 'redis',  // this can be omitted because it is the default
        host: 'localhost',
        port: 6379,
        distDir: function(context) {
          return context.commandOptions.buildDir;
        }
      };
    }
```

adding also this to `ember-cli-build.js`
```
 emberCLIDeploy: {                                                               
   configFile: 'config/deploy.js',                                               
   runOnPostBuild: (env === 'development') ? 'development-postbuild' : false,    
   shouldActivate: true                                                          
 },    
```
Todo:
====

* [x] tests?
* [x] check if `postBuild` fires even during deploy..
* [x] add info to readme

Notes:
======

* `index.js` was updated to return an object from the exports instead of a
constructor, this allows the postBuild hook to have the proper context
and hence get access to `this.project` and similar.

* ~~currently the code lives inside `lib/commands/deploy.js`, I'm not
convinced it's a good idea but we do need access to a bunch of stuff
there (hooks, config, the deploy pipeline)~~

* ~~added `runOnPostBuild` option in ENV~~


* ~~maybe a separate pipeline is a good idea? any suggestion on how to
better handle hooks?~~

* ~~will this fire during a "proper" deploy as well? we should prevent it if so (I haven't tested yet)~~