### PR TITLE
Correct typo; commandOptions are a local var

### DIFF
--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -22,7 +22,7 @@ module.exports = {
       ui: this.ui,
       deployTarget: commandOptions.deployTarget,
       deployConfigFile: commandOptions.deployConfigFile,
-      commandOptions: this.commandOptions
+      commandOptions: commandOptions
     });
 
     return deploy.run();


### PR DESCRIPTION
I encountered the `--activate true` option not working and discovered this (presumed) typo. Not sure if there's a great way to write a test for this or if it matters for a typo.