### PR TITLE
fix active links in docs nav

### DIFF
--- a/_data/navs.yml
+++ b/_data/navs.yml
@@ -33,12 +33,12 @@ v0.5.x:
 
   - section: Deployment Strategies
   - label: Overview
-    path: 'deployment-strategies-overview'
+    path: 'deployment-strategies-overview/'
   - label: The Lightning Strategy
 
   - section: Examples
   - label: Lightning Strategy
-    path: 'lightning-strategy-examples'
+    path: 'lightning-strategy-examples/'
 
 v0.4.x:
   - section: Getting started


### PR DESCRIPTION
previously I forgot to add the trailing `/` is seems necessary
to mark link as active