### PR TITLE
Use npm install when installing plugin base

### DIFF
--- a/docs/v0.5.x/writing-a-plugin.md
+++ b/docs/v0.5.x/writing-a-plugin.md
@@ -86,7 +86,7 @@ a [base plugin](https://github.com/ember-cli-deploy/ember-cli-deploy-plugin) tha
 To extend the base plugin, first you need to install it:
 
 ```bash
-ember install ember-cli-deploy-plugin
+npm install ember-cli-deploy-plugin --save
 ```
 
 Then you need to extend it like this:


### PR DESCRIPTION
When creating an ember-cli-deploy plugin, the base ember-cli-deploy-plugin module needs to be saved in the `package.json` under `dependencies`, not `devDependencies`. Using `ember install` as previously instructed saves ember-cli-deploy-plugin under `devDependencies` (which we don't want) and switching to `npm install --save` saves ember-cli-deploy-plugin under `dependencies` (which we do want).

This change matches the instructions found in the ember-cli-deploy-plugin README: https://github.com/ember-cli-deploy/ember-cli-deploy-plugin/blob/master/README.md