### PR TITLE
Update wording and code block format for plugin execution order

### DIFF
--- a/docs/v0.5.x/writing-a-plugin.md
+++ b/docs/v0.5.x/writing-a-plugin.md
@@ -362,7 +362,8 @@ And every pipeline hook run thereafter will be able to access the `uploadedAt` p
 #### Custom plugin execution order
 
 `ember-cli-deploy` respects the addon ordering from `ember-cli`.
-If you find yourself requiring properties from another plugin in the same hook as it was set, you can configure `ember-cli` to load the plugins in a certain order, by specify plugin ordering (and thus property availability) in package.json,
+If you find yourself requiring properties from another plugin in the same hook as it was set, you can configure `ember-cli` to load the plugins in a certain order, by specifying plugin ordering (and thus property availability) in package.json:
+
 ```javascript
 "ember-addon": {
    after: "ember-cli-deploy-funky-plugin"


### PR DESCRIPTION
- The live site currently is printing out the `javascript` meant to trigger the syntax on the code block, so I added the extra newline necessary to render this properly
- I also adjusted one word for clarity (changed "specify" to "specifying")