### PR TITLE
Remove temporary fix for broccoli-asset-rev

### DIFF
--- a/docs/v0.5.x/upgrading-apps.md
+++ b/docs/v0.5.x/upgrading-apps.md
@@ -15,7 +15,6 @@ To upgrade an application that used the Lightning Strategy in 0.4.X:
 * add new `dotenv` files `.env.build.environment`
 * add `ember-cli-deploy-revision-data`
 * add `ember-cli-deploy-display-revisions`
-* lock `broccoli-asset-rev` to `2.0.6` (temporary bug)
 
 
 ### Notes:


### PR DESCRIPTION
I’m excited to finally be getting to update to 0.5!

Is it true that this temporary fix is no longer necessary? I have `broccoli-asset-rev` version 2.2.0 and it _seems_ like it’s working.