### PR TITLE
dotenv files were not loaded in time for deploy tasks

### DIFF
--- a/lib/tasks/deploy.js
+++ b/lib/tasks/deploy.js
@@ -1,5 +1,6 @@
 var Task        = require('ember-cli/lib/models/task');
 var existsSync  = require('fs').existsSync;
+var dotenv      = require('dotenv');
 var path        = require('path');
 var PipelineTask = require('../tasks/pipeline');
 
@@ -54,6 +55,15 @@ module.exports = Task.extend({
 
     if (!existsSync(fullPath)) {
       return {};
+    }
+
+    var dotEnvFilename = '.env.deploy.' + this.deployTarget;
+    var dotEnvFilePath = path.join(root, dotEnvFilename);
+
+    if (existsSync(dotEnvFilePath)) {
+      dotenv.load({
+        path: dotEnvFilename
+      });
     }
 
     var fn = require(fullPath);

--- a/node-tests/unit/tasks/deploy-test.js
+++ b/node-tests/unit/tasks/deploy-test.js
@@ -86,6 +86,37 @@ describe('DeployTask', function() {
         });
       });
     });
+
+    describe('setting environment variables from .env', function() {
+      beforeEach(function(){
+        delete process.env.ENVTEST;
+      });
+      it('sets the process.env vars if a .env file exists for deploy environment', function() {
+        var project = {
+          name: function() {return 'test-project';},
+          root: process.cwd(),
+          addons: []
+        };
+
+        assert.isUndefined(process.env.ENVTEST);
+
+        var task = new DeployTask({
+          project: project,
+          ui: mockUi,
+          deployTarget: 'development',
+          deployConfigFile: 'node-tests/fixtures/config/deploy.js',
+          _pipeline: {
+            run: function() {
+              pipelineExecuted = true;
+              return Promise.resolve();
+            }
+          }
+        });
+
+        assert.equal(process.env.ENVTEST, 'SUCCESS');
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
Our deploy-plugin-pack has been preventing us from deploying to production because the the .env file was being loaded too late. Our default `deploy.js` looks like https://github.com/movableink/ember-cli-deploy-ink-pack/blob/master/blueprints/ink-deploy-config/files/config/deploy.js.

The issue arises when the deploy task pulls configuration before dotenv is loaded: https://github.com/ember-cli/ember-cli-deploy/blob/master/lib/tasks/deploy.js#L9. The variables are applied after the fact in the pipleline task: https://github.com/ember-cli/ember-cli-deploy/blob/master/lib/tasks/pipeline.js#L33

This solution seems to be a good interim solution, but I think a better one would be a singular approach to loading the deploy.js file contents.