### PR TITLE
Allow command options to be set in .ember-cli file

### DIFF
--- a/lib/commands/activate.js
+++ b/lib/commands/activate.js
@@ -1,3 +1,5 @@
+var chooseOptionValue = require('./option-value');
+
 module.exports = {
   name: 'deploy:activate',
   description: 'Activates a passed deploy-revision',
@@ -6,7 +8,7 @@ module.exports = {
   availableOptions: [
     { name: 'revision', type: String, required: true },
     { name: 'verbose', type: Boolean },
-    { name: 'deploy-config-file', type: String, default: 'config/deploy.js' }
+    { name: 'deploy-config-file', type: String, description: '(Default: config/deploy.js)' }
   ],
 
   anonymousOptions: [
@@ -15,7 +17,10 @@ module.exports = {
 
   run: function(commandOptions, rawArgs) {
     commandOptions.deployTarget = rawArgs.shift();
-    this.ui.verbose = commandOptions.verbose;
+
+    this.ui.verbose = chooseOptionValue(commandOptions.verbose, this.settings, 'verbose');
+    commandOptions.deployConfigFile = chooseOptionValue(commandOptions.deployConfigFile, this.settings, 'deploy-config-file', 'config/deploy.js');
+
     process.env.DEPLOY_TARGET = commandOptions.deployTarget;
 
     var ReadConfigTask = require('../tasks/read-config');

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -1,3 +1,5 @@
+var chooseOptionValue = require('./option-value');
+
 module.exports = {
   name: 'deploy',
   description: 'Deploys an ember-cli app',
@@ -8,14 +10,18 @@ module.exports = {
   ],
 
   availableOptions: [
-    { name: 'deploy-config-file', type: String, default: 'config/deploy.js' },
+    { name: 'deploy-config-file', type: String, description: '(Default: config/deploy.js)' },
     { name: 'verbose', type: Boolean },
     { name: 'activate', type: Boolean }
   ],
 
   run: function(commandOptions, rawArgs) {
     commandOptions.deployTarget = rawArgs.shift();
-    this.ui.verbose = commandOptions.verbose;
+
+    commandOptions.deployConfigFile = chooseOptionValue(commandOptions.deployConfigFile, this.settings, 'deploy-config-file', 'config/deploy.js');
+    this.ui.verbose = chooseOptionValue(commandOptions.verbose, this.settings, 'verbose');
+    commandOptions.activate = chooseOptionValue(commandOptions.activate, this.settings, 'activate');
+
     process.env.DEPLOY_TARGET = commandOptions.deployTarget;
 
     var ReadConfigTask = require('../tasks/read-config');

--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -1,3 +1,5 @@
+var chooseOptionValue = require('./option-value');
+
 module.exports = {
   name: 'deploy:list',
   description: 'Lists the currently uploaded deploy-revisions',
@@ -8,14 +10,18 @@ module.exports = {
   ],
 
   availableOptions: [
-    { name: 'deploy-config-file', type: String, default: 'config/deploy.js' },
+    { name: 'deploy-config-file', type: String, description: '(Default: config/deploy.js)' },
     { name: 'verbose', type: Boolean },
-    { name: 'amount', type: Number, default: 10 }
+    { name: 'amount', type: Number, description: '(Default: 10)' }
   ],
 
   run: function(commandOptions, rawArgs) {
     commandOptions.deployTarget = rawArgs.shift();
-    this.ui.verbose = commandOptions.verbose;
+
+    commandOptions.deployConfigFile = chooseOptionValue(commandOptions.deployConfigFile, this.settings, 'deploy-config-file', 'config/deploy.js');
+    this.ui.verbose = chooseOptionValue(commandOptions.verbose, this.settings, 'verbose');
+    commandOptions.amount = chooseOptionValue(commandOptions.amount, this.settings, 'amount', 10);
+
     process.env.DEPLOY_TARGET = commandOptions.deployTarget;
 
     var ReadConfigTask = require('../tasks/read-config');

--- a/lib/commands/option-value.js
+++ b/lib/commands/option-value.js
@@ -1,0 +1,9 @@
+module.exports = function(commandOption, settings, optionKey, defaultValue) {
+  if (commandOption !== undefined) {
+    return commandOption;
+  }
+  if (settings && settings['ember-cli-deploy'] && settings['ember-cli-deploy'][optionKey] !== undefined) {
+    return settings['ember-cli-deploy'][optionKey];
+  }
+  return defaultValue;
+};


### PR DESCRIPTION
This is a crude first attempt at using a setting within a project's `.ember-cli` file to get verbose deploy outputs on every deploy by default. It is used by simply adding `"deployVerbose": true` to your project's `.ember-cli` file.

The implementation is inspired by ember-cli's own `usePods` setting (code: https://github.com/ember-cli/ember-cli/blob/3c615aa55dfe6be1adf14ef67e74028b09560138/lib/commands/destroy.js#L68-L70) so that the `--verbose` flag can still be used with `ember deploy` to reverse the default.

Potential areas for feedback:
- [x] Do we like the setting name `deployVerbose`? I believe this could even be nested as `"deploy": { "verbose": true }` if we want to go down the road of putting more of these settings (such as `activateOnDeploy`) in the `.ember-cli` file.
- [x] Is there a style or readability preference between reversing the value of `this.ui.verbose` after it's assigned (as implemented), conditionally assigning the value `this.ui.verbose`, or using a one-line ternary assignment?
- [ ] Testing: how and where should this be tested? I don't see any comparable tests in this project that would be easily adapted to test the input from `.ember-cli`. Feedback or direction here would be especially welcomed.