### PR TITLE
Update README.md to ember install vs. npm install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simple, flexible deployment for your Ember CLI app
 ## Installation
 
 ```
-npm install ember-cli-deploy --save-dev
+ember install ember-cli-deploy
 ```
 ## Quick start
 


### PR DESCRIPTION
So the default blueprint is run.