### PR TITLE
[DOC] Add ember-cli-deploy-webhooks to plugins

### DIFF
--- a/docs/v0.5.x/plugins.md
+++ b/docs/v0.5.x/plugins.md
@@ -26,7 +26,7 @@ The following plugins have been developed by community members:
   - [ember-cli-deploy-git-tag](https://github.com/minutebase/ember-cli-deploy-git-tag) - tag deploys in git
   - [ember-cli-deploy-hipchat](https://github.com/blimmer/ember-cli-deploy-hipchat) - send a message to HipChat
   - [ember-cli-deploy-mysql](https://github.com/mwpastore/ember-cli-deploy-mysql) - deploy index.html to MySQL/MariaDB
-  - [ember-cli-deploy-notifications](https://github.com/simplabs/ember-cli-deploy-notifications) - notify external services of successful deploys
+  - [ember-cli-deploy-webhooks](https://github.com/simplabs/ember-cli-deploy-webhooks) - call webhooks during deployments
   - [ember-cli-deploy-notify-firebase](https://github.com/minutebase/ember-cli-deploy-notify-firebase) - update a path in Firebase on activation
   - [ember-cli-deploy-sentry](https://github.com/dschmidt/ember-cli-deploy-sentry) - upload javascript sourcemaps to sentry
   - [ember-cli-deploy-rollbar](https://github.com/netguru/ember-cli-deploy-rollbar) - include Rollbar snippet and upload javascript sourcemaps to Rollbar

--- a/docs/v0.6.x/plugins.md
+++ b/docs/v0.6.x/plugins.md
@@ -26,7 +26,7 @@ The following plugins have been developed by community members:
   - [ember-cli-deploy-git-tag](https://github.com/minutebase/ember-cli-deploy-git-tag) - tag deploys in git
   - [ember-cli-deploy-hipchat](https://github.com/blimmer/ember-cli-deploy-hipchat) - send a message to HipChat
   - [ember-cli-deploy-mysql](https://github.com/mwpastore/ember-cli-deploy-mysql) - deploy index.html to MySQL/MariaDB
-  - [ember-cli-deploy-notifications](https://github.com/simplabs/ember-cli-deploy-notifications) - notify external services of successful deploys
+  - [ember-cli-deploy-webhooks](https://github.com/simplabs/ember-cli-deploy-webhooks) - call webhooks during deployments
   - [ember-cli-deploy-notify-firebase](https://github.com/minutebase/ember-cli-deploy-notify-firebase) - update a path in Firebase on activation
   - [ember-cli-deploy-sentry](https://github.com/dschmidt/ember-cli-deploy-sentry) - upload javascript sourcemaps to sentry
   - [ember-cli-deploy-rollbar](https://github.com/netguru/ember-cli-deploy-rollbar) - include Rollbar snippet and upload javascript sourcemaps to Rollbar


### PR DESCRIPTION
`ember-cli-deploy-notifications` was renamed `-webhooks`. That
should be reflected in the plugin docs as well.