### PR TITLE
Fix s3-index configuration example in docs/s3-walkthrough

### DIFF
--- a/docs/v0.6.x/s3-walkthrough.md
+++ b/docs/v0.6.x/s3-walkthrough.md
@@ -173,7 +173,7 @@ Of these three plugins, only s3-index needs additional configuration. For the ot
         region: '<the-region-your-bucket-is-in>'
       },
 
-      s3-index: {
+      's3-index': {
         accessKeyId: '<your-aws-access-key>',
         secretAccessKey: '<your-aws-secret>',
         bucket: '<your-s3-bucket>',


### PR DESCRIPTION
The property name `s3-index` should have quotes, otherwise the JavaScript may not be valid.

This should fix the issue.