### PR TITLE
Fix the example .ember-cli config

### DIFF
--- a/docs/v0.6.x/default-cli-options.md
+++ b/docs/v0.6.x/default-cli-options.md
@@ -14,7 +14,7 @@ If you want to apply changes to just ember-cli-deploy commands, nest the configu
 // .ember-cli
 {
   "ember-cli-deploy": {
-    verbose: true
+    "verbose": true
   }
 }
 ```


### PR DESCRIPTION
Wrap the `verbose` option in double-quotes because without
them it's not valid JSON and we get errors.

```
throw "Error when parsing file in " + path + ". Make sure that you have a valid JSON."
    ^
Error when parsing file in /Users/danny/src/testapp/.ember-cli. Make sure that you have a valid JSON.
```